### PR TITLE
Fix state park audio slug mismatches

### DIFF
--- a/src/utils/audioPaths.js
+++ b/src/utils/audioPaths.js
@@ -1,6 +1,7 @@
 const CDN_BASE = 'https://resonant-landscapes.b-cdn.net/';
 const PARK_SLUG_OVERRIDES = {
   'Custer State Park': 'Custer-State',
+  'Palisades State Park': 'Palisades-State',
 };
 
 export function formatParkSlug(parkName) {

--- a/src/utils/audioPaths.js
+++ b/src/utils/audioPaths.js
@@ -1,6 +1,13 @@
 const CDN_BASE = 'https://resonant-landscapes.b-cdn.net/';
+const PARK_SLUG_OVERRIDES = {
+  'Custer State Park': 'Custer-State',
+};
 
 export function formatParkSlug(parkName) {
+  if (PARK_SLUG_OVERRIDES[parkName]) {
+    return PARK_SLUG_OVERRIDES[parkName];
+  }
+
   return parkName
     .replace(/\b(State Park|Historic State Park)\b/g, '')
     .trim()

--- a/tests/audio-paths.test.mjs
+++ b/tests/audio-paths.test.mjs
@@ -31,7 +31,20 @@ test('safari variants use wav assets', () => {
   }
 });
 
+test('Custer State Park uses the CDN slug override for both browser families', () => {
+  const safariVariants = getParkAudioVariants('Custer State Park', stateParks, 'Safari');
+  const chromeVariants = getParkAudioVariants('Custer State Park', stateParks, 'Chrome');
+
+  assert.ok(safariVariants);
+  assert.ok(chromeVariants);
+  assert.match(safariVariants[12][0], /\/sounds-wav\/Custer-State-7-001_8ch\.wav$/);
+  assert.match(safariVariants[12][1], /\/sounds-wav\/Custer-State-7-001_mono\.wav$/);
+  assert.match(chromeVariants[12][0], /\/sounds\/Custer-State-7-001_8ch\.m4a$/);
+  assert.match(chromeVariants[12][1], /\/sounds\/Custer-State-7-001_mono\.m4a$/);
+});
+
 test('slug formatting matches current CDN naming convention', () => {
+  assert.equal(formatParkSlug('Custer State Park'), 'Custer-State');
   assert.equal(formatParkSlug('Fort Sisseton Historic State Park'), 'Fort-Sisseton');
   assert.equal(formatParkSlug('Good Earth State Park'), 'Good-Earth');
   assert.equal(formatParkSlug('Bear Butte State Park'), 'Bear-Butte');

--- a/tests/audio-paths.test.mjs
+++ b/tests/audio-paths.test.mjs
@@ -43,8 +43,21 @@ test('Custer State Park uses the CDN slug override for both browser families', (
   assert.match(chromeVariants[12][1], /\/sounds\/Custer-State-7-001_mono\.m4a$/);
 });
 
+test('Palisades State Park uses the CDN slug override for both browser families', () => {
+  const safariVariants = getParkAudioVariants('Palisades State Park', stateParks, 'Safari');
+  const chromeVariants = getParkAudioVariants('Palisades State Park', stateParks, 'Chrome');
+
+  assert.ok(safariVariants);
+  assert.ok(chromeVariants);
+  assert.match(safariVariants[0][0], /\/sounds-wav\/Palisades-State-1-001_8ch\.wav$/);
+  assert.match(safariVariants[0][1], /\/sounds-wav\/Palisades-State-1-001_mono\.wav$/);
+  assert.match(chromeVariants[0][0], /\/sounds\/Palisades-State-1-001_8ch\.m4a$/);
+  assert.match(chromeVariants[0][1], /\/sounds\/Palisades-State-1-001_mono\.m4a$/);
+});
+
 test('slug formatting matches current CDN naming convention', () => {
   assert.equal(formatParkSlug('Custer State Park'), 'Custer-State');
+  assert.equal(formatParkSlug('Palisades State Park'), 'Palisades-State');
   assert.equal(formatParkSlug('Fort Sisseton Historic State Park'), 'Fort-Sisseton');
   assert.equal(formatParkSlug('Good Earth State Park'), 'Good-Earth');
   assert.equal(formatParkSlug('Bear Butte State Park'), 'Bear-Butte');


### PR DESCRIPTION
## Summary
Fix CDN filename mismatches for real park audio assets that were causing 404s on device.

## Changes
- add explicit slug override for `Custer State Park` -> `Custer-State`
- add explicit slug override for `Palisades State Park` -> `Palisades-State`
- add regression tests for both Safari `sounds-wav/*.wav` and Chrome `sounds/*.m4a` URL generation

## Verification
- ran `node --test tests/audio-paths.test.mjs`
- verified corrected CDN paths return `200` for both Custer and Palisades examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio file resolution for specific parks (Custer State Park, Palisades State Park) by implementing explicit CDN asset mappings to ensure correct file delivery across Safari and Chrome browsers.

* **Tests**
  * Added comprehensive test coverage verifying audio file paths are correctly resolved for multiple parks and browsers, confirming proper mapping of eight-channel and mono audio variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->