### PR TITLE
Fix double FOARenderer initialization from React StrictMode

### DIFF
--- a/src/contexts/AudioContextProvider.tsx
+++ b/src/contexts/AudioContextProvider.tsx
@@ -58,6 +58,7 @@ const AudioContextProvider = ({ children }: { children: React.ReactNode }) => {
     const [isPlaying, setIsPlaying] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [loadError, setLoadError] = useState<string | null>(null);
+    const audioInitializedRef = useRef(false);
     const bufferSourceRef = useRef<AudioBufferSourceNode | null>(null);
     const lastAudioEventRef = useRef<string | null>(null);
     const activeLoadRequestIdRef = useRef(0);
@@ -298,13 +299,10 @@ const AudioContextProvider = ({ children }: { children: React.ReactNode }) => {
         }
     }, [isPlaying, syncAudioDebug]);
 
-    const cleanupBuffers = useCallback(() => {
-        if (buffers) {
-            setBuffers(null);
-        }
-    }, [buffers]);
-
     useEffect(() => {
+        if (audioInitializedRef.current) return;
+        audioInitializedRef.current = true;
+
         const initAudio = async () => {
             try {
                 const AudioContextCtor = window.AudioContext
@@ -326,17 +324,6 @@ const AudioContextProvider = ({ children }: { children: React.ReactNode }) => {
         };
 
         initAudio();
-
-        return () => {
-            if (audioContext) {
-                audioContext.close();
-            }
-            if (resonanceAudioScene) {
-                resonanceAudioScene.dispose();
-            }
-            cleanupBuffers();
-        };
-
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
The useEffect cleanup had stale closures (audioContext and resonanceAudioScene were always null at capture time), making it a no-op. React StrictMode's mount/unmount/remount cycle then ran initAudio() twice, creating two AudioContext + ResonanceAudio instances and two FOARenderers.

Added audioInitializedRef guard to prevent double initialization while allowing genuine remounts to re-initialize. Removed the dead cleanup callback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio initialization to run only once per component lifecycle, preventing redundant setup operations during re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->