### PR TITLE
Remove audio prop drilling from geolocation controller

### DIFF
--- a/src/components/GeolocationMap.tsx
+++ b/src/components/GeolocationMap.tsx
@@ -21,7 +21,7 @@ import HelpModal from "./HelpModal";
 import ParkModal from "./ParkModal";
 import ParkFeatureLayers from "./ParkFeatureLayers";
 import GeolocationDebugPanel from "./GeolocationDebugPanel";
-import { useAudioEngine } from "../contexts/AudioContextProvider";
+import { useAudioContext, useAudioEngine } from "../contexts/AudioContextProvider";
 import { useGeolocationTracking } from "../hooks/useGeolocationTracking";
 import { useRenderDebug } from "../hooks/useRenderDebug";
 import stateParks from "../data/stateParks.json";
@@ -63,18 +63,12 @@ const GeolocationPositionLayer = memo(function GeolocationPositionLayer({
 const GeolocationTrackingController = memo(function GeolocationTrackingController({
     debug,
     map,
-    resonanceAudioScene,
-    stopSound,
-    preloadBuffers,
-    audioContext,
 }: {
     debug: boolean;
     map: ReturnType<typeof useOL>["map"];
-    resonanceAudioScene: ReturnType<typeof useAudioEngine>["resonanceAudioScene"];
-    stopSound: ReturnType<typeof useAudioEngine>["stopSound"];
-    preloadBuffers: ReturnType<typeof useAudioEngine>["preloadBuffers"];
-    audioContext: ReturnType<typeof useAudioEngine>["audioContext"];
 }): JSX.Element {
+    const { preloadBuffers, resonanceAudioScene, stopSound } = useAudioEngine();
+    const { audioContext } = useAudioContext();
     const {
         accuracy,
         debugPermission,
@@ -158,12 +152,6 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
 });
 
 function GeolocationOverlay({ debug = false }: { debug?: boolean }): JSX.Element {
-    const {
-        resonanceAudioScene,
-        stopSound,
-        preloadBuffers,
-        audioContext,
-    } = useAudioEngine();
     const { map } = useOL();
     const parkFeatures = useMemo(
         () => (debug ? [testPark, ...scaledPoints] : scaledPoints).map(toParkFeature),
@@ -181,10 +169,6 @@ function GeolocationOverlay({ debug = false }: { debug?: boolean }): JSX.Element
             <GeolocationTrackingController
                 debug={debug}
                 map={map}
-                resonanceAudioScene={resonanceAudioScene}
-                stopSound={stopSound}
-                preloadBuffers={preloadBuffers}
-                audioContext={audioContext}
             />
         </div>
     );


### PR DESCRIPTION
## Summary
- remove audio engine/context props from `GeolocationTrackingController`
- consume audio dependencies directly inside the controller via `useAudioEngine()` and `useAudioContext()`
- simplify `GeolocationOverlay` so it no longer forwards unused audio props

## Verification
- `npm run lint`
- `npm run build`

Closes `rl-cjc`.