### PR TITLE
Move park modal state into geolocation controller

### DIFF
--- a/src/components/GeolocationMap.tsx
+++ b/src/components/GeolocationMap.tsx
@@ -75,16 +75,15 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
     preloadBuffers: ReturnType<typeof useAudioEngine>["preloadBuffers"];
     audioContext: ReturnType<typeof useAudioEngine>["audioContext"];
 }): JSX.Element {
+    const [parkModalOpen, setParkModalOpen] = useState(false);
     const {
         accuracy,
         debugPermission,
         onGeolocationChange,
         parkDistance,
-        parkModalOpen,
         parkName,
         prefetchParkName,
         position,
-        setParkModalOpen,
         userOrientationEnabled,
     } = useGeolocationTracking({
         debug,
@@ -123,6 +122,10 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
 
         void preloadBuffers(prefetchUrls);
     }, [audioContext, prefetchUrls, preloadBuffers]);
+
+    useEffect(() => {
+        setParkModalOpen(Boolean(parkName));
+    }, [parkName]);
 
     return (
         <>

--- a/src/hooks/useGeolocationTracking.ts
+++ b/src/hooks/useGeolocationTracking.ts
@@ -57,7 +57,6 @@ export function useGeolocationTracking({
 }: UseGeolocationTrackingOptions) {
     const [position, setPosition] = useState<number[] | null>(fromLonLat([0, 0]));
     const [accuracy, setAccuracy] = useState<LineString | null>(null);
-    const [parkModalOpen, setParkModalOpen] = useState(false);
     const [parkName, setParkName] = useState("");
     const [parkDistance, setParkDistance] = useState(0);
     const [prefetchParkName, setPrefetchParkName] = useState("");
@@ -141,8 +140,7 @@ export function useGeolocationTracking({
 
         const nearbyPark = parkFeatures.find((park) => distanceInMeters(userLocation, park.scaledCoords) < maxDistance);
 
-        if (nearbyPark && !parkModalOpen) {
-            setParkModalOpen(true);
+        if (nearbyPark && nearbyPark.name !== parkName) {
             setParkName(nearbyPark.name);
             setCurrentParkLocation(nearbyPark.scaledCoords);
         }
@@ -158,11 +156,14 @@ export function useGeolocationTracking({
             setUserOrientationEnabled(currentDistance < 5);
         }
 
-        if (currentDistance > maxDistance && parkModalOpen) {
-            setParkModalOpen(false);
+        if (currentDistance > maxDistance) {
+            setParkName("");
+            setParkDistance(0);
+            setCurrentParkLocation(null);
+            setUserOrientationEnabled(false);
             stopSound();
         }
-    }, [currentParkLocation, map, parkFeatures, parkModalOpen, resonanceAudioScene, stopSound, view]);
+    }, [currentParkLocation, map, parkFeatures, parkName, resonanceAudioScene, stopSound, view]);
 
     const onGeolocationChange = useCallback((event: { target: OLGeoLoc }) => {
         const geoloc = event.target as OLGeoLoc;
@@ -208,11 +209,9 @@ export function useGeolocationTracking({
         onGeolocationChange,
         parkDistance,
         parkFeatures,
-        parkModalOpen,
         parkName,
         prefetchParkName,
         position,
-        setParkModalOpen,
         userOrientationEnabled,
     };
 }


### PR DESCRIPTION
## Summary
- move `parkModalOpen` ownership from `useGeolocationTracking` into `GeolocationTrackingController`
- keep the hook focused on proximity and park state instead of direct UI visibility state
- reset park-related tracking state when leaving range while letting the component decide whether to show the modal

## Verification
- `npm run lint`
- `npm run build`

Closes `rl-r7c`.