### PR TITLE
Move map view mutations into geolocation controller

### DIFF
--- a/src/components/GeolocationMap.tsx
+++ b/src/components/GeolocationMap.tsx
@@ -29,6 +29,25 @@ import { pickSoundPath } from "../utils/audioPaths";
 import scaledPoints, { testPark } from "../utils/scaledParks";
 import locationIcon from "../assets/geolocation_marker_heading.png";
 
+function getCenterWithHeading(
+    map: ReturnType<typeof useOL>["map"],
+    position: [number, number],
+    rotation: number,
+    resolution: number
+) {
+    const size = map?.getSize();
+    if (!size) {
+        return position;
+    }
+
+    const height = size[1];
+
+    return [
+        position[0] - (Math.sin(rotation) * height * resolution) / 4,
+        position[1] + (Math.cos(rotation) * height * resolution) / 4,
+    ] as [number, number];
+}
+
 function toParkFeature(park: { name: string; scaledCoords: number[] }) {
     return {
         name: park.name,
@@ -88,7 +107,6 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
         userOrientationEnabled,
     } = useGeolocationTracking({
         debug,
-        map,
         resonanceAudioScene,
         stopSound,
     });
@@ -123,6 +141,17 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
 
         void preloadBuffers(prefetchUrls);
     }, [audioContext, prefetchUrls, preloadBuffers]);
+
+    useEffect(() => {
+        const view = map?.getView();
+        if (!view || !position) {
+            return;
+        }
+
+        const rotation = -position[2];
+        view.setCenter(getCenterWithHeading(map, [position[0], position[1]], rotation, view.getResolution() ?? 0));
+        view.setRotation(rotation);
+    }, [map, position]);
 
     return (
         <>

--- a/src/hooks/useGeolocationTracking.ts
+++ b/src/hooks/useGeolocationTracking.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type Map from "ol/Map";
 import { Geolocation as OLGeoLoc } from "ol";
 import { LineString } from "ol/geom";
 import { fromLonLat, toLonLat } from "ol/proj";
@@ -26,7 +25,6 @@ function toParkFeature(park: { name: string; scaledCoords: number[] }): ParkFeat
 
 interface UseGeolocationTrackingOptions {
     debug: boolean;
-    map: Map | undefined;
     resonanceAudioScene: ResonanceAudio | null;
     stopSound: () => void;
 }
@@ -35,23 +33,8 @@ function mod(n: number) {
     return ((n % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
 }
 
-function getCenterWithHeading(map: Map | undefined, position: Coordinate, rotation: number, resolution: number) {
-    const size = map?.getSize();
-    if (!size) {
-        return position;
-    }
-
-    const height = size[1];
-
-    return [
-        position[0] - (Math.sin(rotation) * height * resolution) / 4,
-        position[1] + (Math.cos(rotation) * height * resolution) / 4,
-    ] as Coordinate;
-}
-
 export function useGeolocationTracking({
     debug,
-    map,
     resonanceAudioScene,
     stopSound,
 }: UseGeolocationTrackingOptions) {
@@ -69,7 +52,6 @@ export function useGeolocationTracking({
     const previousMRef = useRef(0);
     const positionsRef = useRef(new LineString([], "XYZM"));
 
-    const view = map?.getView();
     const maxDistance = 15;
     const prefetchDistance = 40;
     const parkFeatures = useMemo<ParkFeature[]>(
@@ -108,10 +90,6 @@ export function useGeolocationTracking({
     }, [debug]);
 
     const updateView = useCallback(() => {
-        if (!view) {
-            return;
-        }
-
         let m = Date.now() - deltaMeanRef.current * 1.5;
         m = Math.max(m, previousMRef.current);
         previousMRef.current = m;
@@ -121,8 +99,6 @@ export function useGeolocationTracking({
             return;
         }
 
-        view.setCenter(getCenterWithHeading(map, [coordinates[0], coordinates[1]], -coordinates[2], view.getResolution() ?? 0));
-        view.setRotation(-coordinates[2]);
         setPosition(coordinates);
 
         const userLocation = toLonLat([coordinates[0], coordinates[1]]) as Coordinate;
@@ -162,7 +138,7 @@ export function useGeolocationTracking({
             setParkModalOpen(false);
             stopSound();
         }
-    }, [currentParkLocation, map, parkFeatures, parkModalOpen, resonanceAudioScene, stopSound, view]);
+    }, [currentParkLocation, parkFeatures, parkModalOpen, resonanceAudioScene, stopSound]);
 
     const onGeolocationChange = useCallback((event: { target: OLGeoLoc }) => {
         const geoloc = event.target as OLGeoLoc;


### PR DESCRIPTION
## Summary
- move OpenLayers view centering and rotation mutations out of `useGeolocationTracking`
- keep the hook focused on tracking state and returned position data
- apply map view updates inside `GeolocationTrackingController` based on the hook output

## Verification
- `npm run lint`
- `npm run build`
- `npm run sim:path`

Closes `rl-fjj`.