### PR TITLE
Select nearest in-range park instead of first array match

### DIFF
--- a/src/hooks/useGeolocationTracking.ts
+++ b/src/hooks/useGeolocationTracking.ts
@@ -6,6 +6,7 @@ import type { ResonanceAudio } from "resonance-audio";
 
 import scaledPoints, { testPark } from "../utils/scaledParks";
 import { distanceInMeters } from "../utils/geo";
+import { selectNearestInRangePark } from "../utils/parkSelection";
 
 type Coordinate = [number, number];
 
@@ -114,7 +115,7 @@ export function useGeolocationTracking({
 
         setPrefetchParkName(closestPark && closestParkDistance < prefetchDistance ? closestPark.name : "");
 
-        const nearbyPark = parkFeatures.find((park) => distanceInMeters(userLocation, park.scaledCoords) < maxDistance);
+        const nearbyPark = selectNearestInRangePark(userLocation, parkFeatures, maxDistance);
 
         if (nearbyPark && nearbyPark.name !== parkName) {
             setParkName(nearbyPark.name);

--- a/src/utils/parkSelection.js
+++ b/src/utils/parkSelection.js
@@ -1,0 +1,24 @@
+import { distanceInMeters } from "./geo";
+
+/**
+ * Returns the nearest park within maxDistance of userLocation,
+ * or null if no parks qualify. Ignores array order.
+ *
+ * @param {[number, number]} userLocation - [longitude, latitude]
+ * @param {{ name: string; scaledCoords: [number, number] }[]} parks
+ * @param {number} maxDistance - meters
+ */
+export function selectNearestInRangePark(userLocation, parks, maxDistance) {
+  let nearest = null;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (const park of parks) {
+    const distance = distanceInMeters(userLocation, park.scaledCoords);
+    if (distance < maxDistance && distance < nearestDistance) {
+      nearest = park;
+      nearestDistance = distance;
+    }
+  }
+
+  return nearest;
+}

--- a/tests/park-selection.spec.ts
+++ b/tests/park-selection.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for nearest-in-range park selection logic.
+ * These tests run without a browser and verify the selection algorithm
+ * chooses the nearest park within range, not the first one in array order.
+ */
+import { test, expect } from "@playwright/test";
+import { selectNearestInRangePark } from "../src/utils/parkSelection";
+
+type Park = {
+  name: string;
+  scaledCoords: [number, number];
+};
+
+const MAX_DISTANCE = 15;
+
+// Real scaled coordinates from the path-replay scenario (Sica approach 3 position).
+// At this point both parks are in range but Sica Hollow is nearer.
+const SICA_HOLLOW: Park = {
+  name: "Sica Hollow State Park",
+  scaledCoords: [-97.11064914495, 44.01336371948],
+};
+
+const HARTFORD_BEACH: Park = {
+  name: "Hartford Beach State Park",
+  scaledCoords: [-97.11059202645, 44.01320393348],
+};
+
+// User is at Sica approach 3: 8.2m from Sica Hollow, 10.6m from Hartford Beach.
+const USER_AT_APPROACH_3: [number, number] = [-97.110649, 44.01329];
+
+test.describe("selectNearestInRangePark", () => {
+  test("returns nearest park when nearer park is later in array", () => {
+    // Hartford Beach (farther, 10.6m) is first; Sica Hollow (nearer, 8.2m) is second.
+    // A find()-based implementation would wrongly return Hartford Beach.
+    const parks: Park[] = [HARTFORD_BEACH, SICA_HOLLOW];
+
+    const result = selectNearestInRangePark(USER_AT_APPROACH_3, parks, MAX_DISTANCE);
+
+    expect(result?.name).toBe("Sica Hollow State Park");
+  });
+
+  test("returns nearest park when nearer park is first in array", () => {
+    const parks: Park[] = [SICA_HOLLOW, HARTFORD_BEACH];
+
+    const result = selectNearestInRangePark(USER_AT_APPROACH_3, parks, MAX_DISTANCE);
+
+    expect(result?.name).toBe("Sica Hollow State Park");
+  });
+
+  test("returns null when no parks are within range", () => {
+    const farAwayUser: [number, number] = [-97.0, 44.0];
+
+    const result = selectNearestInRangePark(farAwayUser, [SICA_HOLLOW, HARTFORD_BEACH], MAX_DISTANCE);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns the single in-range park when only one qualifies", () => {
+    // Only Hartford Beach is in range at Sica approach 1 (Sica Hollow is 27m away).
+    const userAtApproach1: [number, number] = [-97.110649, 44.01312];
+
+    const result = selectNearestInRangePark(userAtApproach1, [SICA_HOLLOW, HARTFORD_BEACH], MAX_DISTANCE);
+
+    expect(result?.name).toBe("Hartford Beach State Park");
+  });
+});

--- a/tests/path-replay.spec.ts
+++ b/tests/path-replay.spec.ts
@@ -5,7 +5,7 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 type ReplayPoint = {
   latitude: number;
@@ -14,11 +14,148 @@ type ReplayPoint = {
   label?: string;
 };
 
+type ParkCandidate = {
+  name: string;
+  distanceMeters: number;
+};
+
+type ParkFeature = {
+  name: string;
+  scaledCoords: [number, number];
+};
+
 const DEFAULT_PATH_FILE = "tests/paths/sica-hollow-approach.json";
+const STATE_PARKS_FILE = "src/data/stateParks.json";
 const defaultStepMs = Number(process.env.PATH_REPLAY_STEP_MS ?? 1500);
 const finalHoldMs = Number(process.env.PATH_REPLAY_FINAL_HOLD_MS ?? 6000);
 const custerHoldMs = Number(process.env.PATH_REPLAY_CUSTER_HOLD_MS ?? 4000);
 const pauseAtPark = process.env.PATH_REPLAY_PAUSE === "1";
+const maxDistanceMeters = 15;
+const neutralPoint: ReplayPoint = {
+  latitude: 44.0115,
+  longitude: -97.1095,
+  label: "Neutral start",
+};
+
+function toRadians(value: number) {
+  return (value * Math.PI) / 180;
+}
+
+function distanceInMeters([lon1, lat1]: [number, number], [lon2, lat2]: [number, number]) {
+  const earthRadiusMeters = 6371008.8;
+  const latDelta = toRadians(lat2 - lat1);
+  const lonDelta = toRadians(lon2 - lon1);
+  const lat1Radians = toRadians(lat1);
+  const lat2Radians = toRadians(lat2);
+
+  const a =
+    Math.sin(latDelta / 2) ** 2 +
+    Math.cos(lat1Radians) *
+      Math.cos(lat2Radians) *
+      Math.sin(lonDelta / 2) ** 2;
+
+  return 2 * earthRadiusMeters * Math.asin(Math.sqrt(a));
+}
+
+function scaleCoordinates(
+  [lon, lat]: [number, number],
+  [referenceLon, referenceLat]: [number, number],
+  scaleLong: number,
+  scaleLat: number
+) {
+  const scaledLong = (lon - referenceLon) * scaleLong;
+  const scaledLat = (lat - referenceLat) * scaleLat;
+
+  return [referenceLon + scaledLong, referenceLat + scaledLat] as [number, number];
+}
+
+async function readParkFeatures(): Promise<ParkFeature[]> {
+  const absoluteFilePath = path.resolve(process.cwd(), STATE_PARKS_FILE);
+  const raw = await fs.readFile(absoluteFilePath, "utf-8");
+  const parsed = JSON.parse(raw) as Array<{ name: string; cords: [number, number] }>;
+  const referencePoint: [number, number] = [-97.110789, 44.012222];
+  const scaleLat = 0.00066;
+  const scaleLong = 0.00045;
+  const testPark: ParkFeature = {
+    name: "Custer Test",
+    scaledCoords: [-97.112994, 44.012224],
+  };
+
+  return [
+    testPark,
+    ...parsed.map((park) => ({
+      name: park.name,
+      scaledCoords: scaleCoordinates(park.cords, referencePoint, scaleLong, scaleLat),
+    })),
+  ];
+}
+
+function getNearbyParks(point: ReplayPoint, parkFeatures: ParkFeature[]): ParkCandidate[] {
+  const userLocation: [number, number] = [point.longitude, point.latitude];
+
+  return parkFeatures
+    .map((park) => ({
+      name: park.name,
+      distanceMeters: distanceInMeters(userLocation, park.scaledCoords),
+    }))
+    .filter((park) => park.distanceMeters < maxDistanceMeters)
+    .sort((left, right) => left.distanceMeters - right.distanceMeters);
+}
+
+function formatNearbyParks(parks: ParkCandidate[]) {
+  if (!parks.length) {
+    return "none";
+  }
+
+  return parks
+    .map((park) => `${park.name}:${park.distanceMeters.toFixed(2)}m`)
+    .join(", ");
+}
+
+async function readDebugParkName(page: Page) {
+  const parkDebug = page.locator("p", { hasText: "Park:" });
+  const rawText = (await parkDebug.textContent()) ?? "";
+
+  return rawText.replace(/^Park:\s*/, "").trim();
+}
+
+async function readDebugCoords(page: Page) {
+  const coordsDebug = page.locator("p", { hasText: "Coords:" });
+  const rawText = (await coordsDebug.textContent()) ?? "";
+
+  return rawText.replace(/^Coords:\s*/, "").trim();
+}
+
+async function ensureDebugPanelExpanded(page: Page) {
+  const parkDebug = page.locator("p", { hasText: "Park:" });
+  if (await parkDebug.count()) {
+    console.log("[test] debug panel already expanded");
+    return;
+  }
+
+  const debugToggle = page.getByRole("button", { name: /open|hide/i }).last();
+  await expect(debugToggle).toBeVisible({ timeout: 10_000 });
+  await debugToggle.click();
+  await expect(parkDebug).toBeVisible({ timeout: 10_000 });
+  console.log("[test] expanded debug panel");
+}
+
+async function dismissWelcomeModal(page: Page) {
+  const welcomeHeading = page.getByRole("heading", { name: "Welcome to Resonant Landscapes" });
+  const continueButton = page.getByRole("button", { name: "Continue" });
+  const modalBackdrop = page.locator("#headlessui-portal-root .fixed.inset-0").first();
+
+  if (!(await welcomeHeading.count())) {
+    return;
+  }
+
+  await expect(welcomeHeading).toBeVisible({ timeout: 10_000 });
+  await expect(continueButton).toBeVisible({ timeout: 10_000 });
+  await continueButton.click();
+  await expect(welcomeHeading).toHaveCount(0, { timeout: 10_000 });
+  await expect(modalBackdrop).toHaveCount(0, { timeout: 10_000 });
+  console.log("[test] dismissed welcome modal");
+}
 
 async function readReplayPoints(): Promise<ReplayPoint[]> {
   const filePath = process.env.PATH_REPLAY_FILE ?? DEFAULT_PATH_FILE;
@@ -53,6 +190,7 @@ test("replays a geolocation path and updates the active park on the map", async 
   });
 
   const replayPoints = await readReplayPoints();
+  const parkFeatures = await readParkFeatures();
   const firstPoint = replayPoints[0];
   const replayPath = "/#/debug";
 
@@ -68,34 +206,34 @@ test("replays a geolocation path and updates the active park on the map", async 
 
   await context.grantPermissions(["geolocation"], { origin: permissionOrigin });
   await context.setGeolocation({
-    latitude: firstPoint.latitude,
-    longitude: firstPoint.longitude,
+    latitude: neutralPoint.latitude,
+    longitude: neutralPoint.longitude,
   });
 
   await page.goto(replayPath);
   await page.waitForLoadState("domcontentloaded");
 
-  const continueButton = page.getByRole("button", { name: "Continue" });
-  if (await continueButton.count()) {
-    await continueButton.click();
-    await expect(page.getByRole("heading", { name: "Welcome to Resonant Landscapes" })).toHaveCount(0);
-  }
+  await dismissWelcomeModal(page);
 
-  const debugToggle = page.getByRole("button", { name: "Open" });
-  await expect(debugToggle).toBeVisible({ timeout: 10_000 });
-  await debugToggle.click();
-  console.log("[test] opened debug panel");
+  await ensureDebugPanelExpanded(page);
 
   console.log(
     `[test] re-applying first point after load: ${firstPoint.label ?? "unnamed"} (${firstPoint.latitude}, ${firstPoint.longitude})`
   );
-  await context.setGeolocation({
-    latitude: firstPoint.latitude,
-    longitude: firstPoint.longitude,
-  });
-  await page.waitForTimeout(firstPoint.waitMs ?? defaultStepMs);
-
+  // On WebKit, subsequent setGeolocation calls don't always trigger watchPosition callbacks.
+  // Keep re-applying the position inside the poll until OL reflects the new coords.
   const parkDebug = page.locator("p", { hasText: "Park:" });
+  await expect
+    .poll(
+      async () => {
+        await context.setGeolocation({ latitude: firstPoint.latitude, longitude: firstPoint.longitude });
+        return readDebugCoords(page);
+      },
+      { timeout: 15_000, intervals: [500] }
+    )
+    .toMatch(new RegExp(firstPoint.latitude.toFixed(3)));
+  console.log(`[test] debug coords after first point: ${await readDebugCoords(page)}`);
+  console.log(`[test] debug park after first point: ${await readDebugParkName(page)}`);
   await expect(parkDebug).toContainText("Custer Test", { timeout: 15_000 });
   console.log("[test] debug panel reports park: Custer Test");
 
@@ -107,14 +245,39 @@ test("replays a geolocation path and updates the active park on the map", async 
   await page.waitForTimeout(custerHoldMs);
 
   for (const [index, point] of replayPoints.slice(1).entries()) {
+    const nearbyParks = getNearbyParks(point, parkFeatures);
+
     console.log(
       `[test] replay point ${index + 2}/${replayPoints.length}: ${point.label ?? "unnamed"} (${point.latitude}, ${point.longitude}) wait=${point.waitMs ?? defaultStepMs}ms`
     );
+    console.log(`[test] in-range parks: ${formatNearbyParks(nearbyParks)}`);
     await context.setGeolocation({
       latitude: point.latitude,
       longitude: point.longitude,
     });
     await page.waitForTimeout(point.waitMs ?? defaultStepMs);
+
+    if (point.label === "Sica approach 3") {
+      expect(nearbyParks.map((park) => park.name)).toEqual([
+        "Sica Hollow State Park",
+        "Hartford Beach State Park",
+      ]);
+      console.log(`[test] expected nearest park at overlap point: ${nearbyParks[0]?.name ?? "none"}`);
+
+      // Keep pumping setGeolocation so the position-smoothing lag converges to this
+      // point. Without pumping, deltaMeanRef stays ~1500ms and the interpolated
+      // position remains near approach 1/2 (only Hartford Beach in range).
+      await expect
+        .poll(
+          async () => {
+            await context.setGeolocation({ latitude: point.latitude, longitude: point.longitude });
+            return readDebugParkName(page);
+          },
+          { timeout: 15_000, intervals: [500] }
+        )
+        .toBe("Sica Hollow State Park");
+      console.log(`[test] selected park at overlap point: ${await readDebugParkName(page)}`);
+    }
   }
 
   const sicaLabel = page.getByRole("heading", { name: "Sica Hollow State Park" });


### PR DESCRIPTION
Extract selectNearestInRangePark() utility and use it in useGeolocationTracking to pick the closest park within range, making selection independent of array order.

Add unit tests (park-selection.spec.ts) that verify nearest-wins when a farther park appears first in the array. Update path-replay spec with pumped setGeolocation at the overlap assertion to handle position-smoothing lag on WebKit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced park selection logic to identify the nearest park within range rather than using first-match selection, improving geolocation-based park tracking accuracy.

* **Tests**
  * Added comprehensive test coverage for park selection and geolocation replay scenarios, including distance-based filtering and multi-park selection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->