### PR TITLE
Consolidate gimbal state into HOARenderer

### DIFF
--- a/src/components/GimbalArrow.tsx
+++ b/src/components/GimbalArrow.tsx
@@ -1,13 +1,17 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 
 import Gimbal from '../utils/Gimbal';
 import { useAudioEngine } from '../contexts/AudioContextProvider';
 import { useRenderDebug } from "../hooks/useRenderDebug";
 
-const GimbalArrow = () => {
+interface GimbalArrowProps {
+    permissionGranted: boolean;
+    onPermissionGranted: () => void;
+}
+
+const GimbalArrow = ({ permissionGranted, onPermissionGranted }: GimbalArrowProps) => {
     const gimbalRef = useRef(new Gimbal());
     const yawDisplayRef = useRef<HTMLSpanElement>(null);
-    const [permissionGranted, setPermissionGranted] = useState(false);
     const { resonanceAudioScene } = useAudioEngine();
     useRenderDebug("GimbalArrow", {
         permissionGranted,
@@ -22,24 +26,23 @@ const GimbalArrow = () => {
                 if (permission === 'granted') {
                     gimbalRef.current.enable();
                     console.log("Permission granted");
-                    setPermissionGranted(true);
-                    localStorage.setItem('deviceOrientationPermission', 'granted'); // Store permission state
+                    onPermissionGranted();
+                    localStorage.setItem('deviceOrientationPermission', 'granted');
                 }
             } catch (error) {
                 console.error("DeviceOrientationEvent.requestPermission error:", error);
             }
         } else {
             // Automatically grant permission if the browser does not support requestPermission
-            setPermissionGranted(true);
+            onPermissionGranted();
         }
-    }, []);
-
+    }, [onPermissionGranted]);
 
     useEffect(() => {
         if (!permissionGranted) {
             requestPermission();
         }
-    }, [])
+    }, []);
 
     useEffect(() => {
         gimbalRef.current.enable();
@@ -96,6 +99,7 @@ const GimbalArrow = () => {
             </div>
         );
     }
+
 
     return (
         <p className="text-xs text-slate-400 tabular-nums">

--- a/src/components/HoaRenderer.tsx
+++ b/src/components/HoaRenderer.tsx
@@ -20,6 +20,7 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
     const { playSound, stopSound, loadBuffers, clearLoadError, cancelPendingLoad } = useAudioEngine();
     const { isLoading, isPlaying, buffers, loadError } = useAudioPlaybackState();
     const [showGimbalArrow, setShowGimbalArrow] = useState(false);
+    const [permissionGranted, setPermissionGranted] = useState(false);
     const [pathError, setPathError] = useState<string | null>(null);
     useRenderDebug("HOARenderer", {
         parkName,
@@ -31,6 +32,7 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
         hasBuffers: Boolean(buffers),
         loadError,
         showGimbalArrow,
+        permissionGranted,
         pathError,
     });
     const audioActionsRef = useRef({
@@ -79,6 +81,7 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
             audioActionsRef.current.clearLoadError();
             audioActionsRef.current.stopSound();
             setShowGimbalArrow(false);
+            setPermissionGranted(false);
         };
     }, [parkName]);
 
@@ -166,7 +169,12 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
 
                     <br></br>
                     {!compact && isPlaying && !showGimbalArrow && <LeavesCanvas parkDistance={parkDistance} />}
-                    {!compact && isPlaying && showGimbalArrow && <GimbalArrow />}
+                    {!compact && isPlaying && showGimbalArrow && (
+                        <GimbalArrow
+                            permissionGranted={permissionGranted}
+                            onPermissionGranted={() => setPermissionGranted(true)}
+                        />
+                    )}
                 </>
             )}
         </div>


### PR DESCRIPTION
Lift permissionGranted out of GimbalArrow and into HOARenderer so both showGimbalArrow and permissionGranted have a single owner. GimbalArrow now receives permissionGranted and onPermissionGranted as props and keeps the iOS permission request logic. Both states reset together when parkName changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component architecture for enhanced state management and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->