### PR TITLE
Redesign modals with botanical zine aesthetic (rl-9w7.1, rl-9w7.2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400&family=Space+Mono&display=swap" rel="stylesheet">
   <!-- <script src="https://cdn.jsdelivr.net/npm/react-render-tracker" data-config="inpage:true"></script> -->
   <!-- <script src="http://138.247.242.164:8097"></script> -->
   <!-- <script src="http://localhost:8097"></script> -->

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, Fragment } from 'react'
+import { useRef, Fragment } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 
 interface HelpModalProps {
@@ -21,13 +21,11 @@ function HelpModal({ isOpen, setIsOpen }: HelpModalProps) {
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                 >
-                    {/* Background */}
-                    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+                    <div className="fixed inset-0 bg-neutral-900/60 transition-opacity" />
                 </Transition.Child>
 
                 <div className="fixed inset-0 w-screen overflow-y-auto">
-                    {/* Container to center the panel */}
-                    <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+                    <div className="flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
                         <Transition.Child
                             as={Fragment}
                             enter="ease-out duration-300"
@@ -37,31 +35,63 @@ function HelpModal({ isOpen, setIsOpen }: HelpModalProps) {
                             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                         >
-                            <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                                <div className="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-                                    <div className="sm:flex sm:items-start">
-                                        <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-                                            <Dialog.Title as="h3" className="text-base font-semibold leading-6 text-gray-900">
-                                                Troubleshooting
-                                            </Dialog.Title>
-
-                                            <p>For best results, turn WiFi off. If you don't hear sound, refresh the page or reopen the browser. Also, make sure geolocation is enabled in your phone/browser settings.</p>
-                                            <br />
-                                            <p>The app has been tested on iOS with Safari. It may not work with other devices or browsers.</p>
-                                            <br />
-                                            <p>Contact <a href='mailto:tate.carson@dsu.edu' className="text-blue-600 visited:text-purple-600 underline">Tate Carson</a> with questions and feedback.</p>
-                                        </div>
-                                    </div>
+                            <Dialog.Panel className="relative w-full rounded-2xl bg-[#8ecdc0] p-8 shadow-2xl sm:my-8 sm:max-w-md">
+                                {/* decorative top rule */}
+                                <div className="mb-6 flex items-center gap-3">
+                                    <div className="h-px flex-1 bg-neutral-900/25" />
+                                    <span className="text-xs text-neutral-900/40 font-space-mono tracking-widest">✦</span>
+                                    <div className="h-px flex-1 bg-neutral-900/25" />
                                 </div>
-                                <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
 
+                                <Dialog.Title
+                                    as="h2"
+                                    className="font-cormorant text-5xl italic font-light tracking-tight text-neutral-900 mb-1"
+                                >
+                                    Troubleshooting
+                                </Dialog.Title>
+                                <p className="font-space-mono text-[10px] tracking-widest uppercase text-neutral-900/50 mb-7">
+                                    things to try
+                                </p>
+
+                                <ul className="font-space-mono space-y-3 text-[12px] leading-relaxed text-neutral-900/75">
+                                    <li className="flex gap-3">
+                                        <span className="select-none text-neutral-900/40">—</span>
+                                        <span>Turn WiFi off for best results.</span>
+                                    </li>
+                                    <li className="flex gap-3">
+                                        <span className="select-none text-neutral-900/40">—</span>
+                                        <span>No sound? Refresh the page or reopen the browser.</span>
+                                    </li>
+                                    <li className="flex gap-3">
+                                        <span className="select-none text-neutral-900/40">—</span>
+                                        <span>Make sure geolocation is enabled in your phone and browser settings.</span>
+                                    </li>
+                                    <li className="flex gap-3">
+                                        <span className="select-none text-neutral-900/40">—</span>
+                                        <span>Tested on iOS with Safari — other devices may not work.</span>
+                                    </li>
+                                    <li className="flex gap-3">
+                                        <span className="select-none text-neutral-900/40">—</span>
+                                        <span>
+                                            Questions?{' '}
+                                            <a
+                                                href="mailto:tate.carson@dsu.edu"
+                                                className="text-neutral-900 underline decoration-neutral-900/40 underline-offset-2 transition-colors hover:decoration-neutral-900"
+                                            >
+                                                Tate Carson
+                                            </a>
+                                        </span>
+                                    </li>
+                                </ul>
+
+                                <div className="mt-8">
                                     <button
                                         type="button"
-                                        className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                                        className="w-full rounded-full bg-neutral-900 px-6 py-3 font-space-mono text-xs tracking-widest uppercase text-white transition-colors hover:bg-neutral-700"
                                         onClick={() => setIsOpen(false)}
                                         ref={cancelButtonRef}
                                     >
-                                        Continue
+                                        Close
                                     </button>
                                 </div>
                             </Dialog.Panel>
@@ -73,4 +103,4 @@ function HelpModal({ isOpen, setIsOpen }: HelpModalProps) {
     )
 }
 
-export default HelpModal; 
+export default HelpModal;

--- a/src/components/HoaRenderer.tsx
+++ b/src/components/HoaRenderer.tsx
@@ -140,23 +140,26 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
                     <button
                         onClick={onTogglePlayback}
                         aria-label={isPlaying ? 'Stop playback' : 'Start playback'}
-                        className={compact ? "inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm" : undefined}
+                        className={compact
+                            ? "inline-flex min-h-[44px] items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 font-space-mono text-xs uppercase tracking-widest text-white transition-colors hover:bg-neutral-700"
+                            : "inline-flex min-h-[44px] min-w-[44px] items-center justify-center"
+                        }
                     >
                         {isPlaying ?
-                        <StopCircleIcon className="h-10 w-10 text-green-600" aria-hidden="true" /> :
-                        <PlayCircleIcon className="h-10 w-10 text-green-600" aria-hidden="true" />}
+                        <StopCircleIcon className={compact ? "h-4 w-4" : "h-12 w-12 text-neutral-900"} aria-hidden="true" /> :
+                        <PlayCircleIcon className={compact ? "h-4 w-4" : "h-12 w-12 text-neutral-900"} aria-hidden="true" />}
                         {compact && <span>{isPlaying ? 'Stop' : 'Play'}</span>}
                     </button>
                     {
                         !compact && isPlaying && parkDistance < 2 &&
                         <Switch.Group>
                             <div className="flex items-center">
-                                <Switch.Label className="mr-4">Enable Body-Oriented Tracking</Switch.Label>
+                                <Switch.Label className="mr-4 font-space-mono text-[11px] uppercase tracking-widest text-neutral-900/70">Body-Oriented Tracking</Switch.Label>
                                 <Switch
                                     checked={showGimbalArrow}
                                     onChange={setShowGimbalArrow}
-                                    className={`${showGimbalArrow ? 'bg-blue-600' : 'bg-gray-200'
-                                        } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+                                    className={`${showGimbalArrow ? 'bg-neutral-900' : 'bg-neutral-200'
+                                        } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-neutral-500 focus:ring-offset-2`}
                                 >
                                     <span
                                         className={`${showGimbalArrow ? 'translate-x-6' : 'translate-x-1'

--- a/src/components/ParkModal.tsx
+++ b/src/components/ParkModal.tsx
@@ -33,13 +33,18 @@ function ParkModal({ setIsOpen, isOpen, parkName, parkDistance, userOrientation,
 
     if (compact) {
         return (
-            <div className="text-left">
-                <div>
-                    <h3 className="text-sm font-semibold leading-6 text-gray-900">{parkName}</h3>
-                    <p className="text-xs text-gray-500">{Math.floor(parkDistance)} meters away</p>
-                    <div className="mt-2">
-                        <HOARenderer parkName={parkName} parkDistance={parkDistance} userOrientation={userOrientation} compact />
+            <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-neutral-900/20 bg-[#8ecdc0] px-5 py-3 shadow-lg">
+                <div className="flex items-center justify-between gap-4">
+                    <div className="min-w-0">
+                        <p className="font-cormorant italic truncate text-xl font-light text-neutral-900">{parkName}</p>
+                        <p className="font-space-mono text-[10px] uppercase tracking-widest text-neutral-900/50">{Math.floor(parkDistance)} m away</p>
                     </div>
+                    <HOARenderer
+                        parkName={parkName}
+                        parkDistance={parkDistance}
+                        userOrientation={userOrientation}
+                        compact
+                    />
                 </div>
             </div>
         );
@@ -57,11 +62,11 @@ function ParkModal({ setIsOpen, isOpen, parkName, parkDistance, userOrientation,
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                 >
-                    <div className="fixed inset-0 bg-gray-500 bg-opacity-10 transition-opacity" />
+                    <div className="fixed inset-0 bg-neutral-900/20 transition-opacity" />
                 </Transition.Child>
 
-                <div className="relative inset-0 z-10 w-screen overflow-y-auto">
-                    <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+                <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+                    <div className="flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
                         <Transition.Child
                             as={Fragment}
                             enter="ease-out duration-300"
@@ -71,27 +76,36 @@ function ParkModal({ setIsOpen, isOpen, parkName, parkDistance, userOrientation,
                             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                         >
-                            <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                                <div className="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-                                    <div className="sm:flex sm:items-start">
-                                        <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-                                            <Dialog.Title as="h3" className="text-base font-semibold leading-6 text-gray-900">
-                                                {parkName}
-                                            </Dialog.Title>
-                                            <p className="text-sm text-gray-500">
-                                                {Math.floor(parkDistance)} meters away
-                                            </p>
-                                            <div className="mt-2">
-                                                <HOARenderer parkName={parkName} parkDistance={parkDistance} userOrientation={userOrientation} />
-                                            </div>
-                                        </div>
-                                    </div>
+                            <Dialog.Panel className="relative w-full rounded-2xl bg-[#8ecdc0] p-8 shadow-2xl sm:my-8 sm:max-w-md">
+                                {/* decorative top rule */}
+                                <div className="mb-6 flex items-center gap-3">
+                                    <div className="h-px flex-1 bg-neutral-900/25" />
+                                    <span className="font-space-mono text-xs tracking-widest text-neutral-900/40">✦</span>
+                                    <div className="h-px flex-1 bg-neutral-900/25" />
                                 </div>
-                                <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
 
+                                <Dialog.Title
+                                    as="h2"
+                                    className="font-cormorant text-5xl italic font-light tracking-tight text-neutral-900"
+                                >
+                                    {parkName}
+                                </Dialog.Title>
+                                <p className="font-space-mono mt-1 text-[10px] uppercase tracking-widest text-neutral-900/50">
+                                    {Math.floor(parkDistance)} meters away
+                                </p>
+
+                                <div className="mt-6">
+                                    <HOARenderer
+                                        parkName={parkName}
+                                        parkDistance={parkDistance}
+                                        userOrientation={userOrientation}
+                                    />
+                                </div>
+
+                                <div className="mt-8">
                                     <button
                                         type="button"
-                                        className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                                        className="w-full rounded-full bg-neutral-900 px-6 py-3 font-space-mono text-xs tracking-widest uppercase text-white transition-colors hover:bg-neutral-700"
                                         onClick={cancel}
                                         ref={cancelButtonRef}
                                     >

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, Fragment } from 'react'
+import { useRef, Fragment } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 
 interface WelcomeModalProps {
@@ -6,7 +6,7 @@ interface WelcomeModalProps {
     setIsOpen: (value: boolean) => void;
 }
 
-function MyDialog({ isOpen, setIsOpen }: WelcomeModalProps) {
+function WelcomeModal({ isOpen, setIsOpen }: WelcomeModalProps) {
     const cancelButtonRef = useRef(null);
 
     return (
@@ -21,13 +21,11 @@ function MyDialog({ isOpen, setIsOpen }: WelcomeModalProps) {
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                 >
-                    {/* Background */}
-                    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+                    <div className="fixed inset-0 bg-neutral-900/60 transition-opacity" />
                 </Transition.Child>
 
                 <div className="fixed inset-0 w-screen overflow-y-auto">
-                    {/* Container to center the panel */}
-                    <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+                    <div className="flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
                         <Transition.Child
                             as={Fragment}
                             enter="ease-out duration-300"
@@ -37,34 +35,39 @@ function MyDialog({ isOpen, setIsOpen }: WelcomeModalProps) {
                             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                         >
-                            <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                                <div className="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-                                    <div className="sm:flex sm:items-start">
-                                        <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-                                            <Dialog.Title as="h1" className="text-base font-semibold leading-6 text-gray-900">
-                                                Welcome to Resonant Landscapes
-                                            </Dialog.Title>
-
-                                            <p>Walk around DSU's campus to hear sounds recorded in each of South Dakota's 13 State Parks.</p>
-                                            <br />
-                                            <p> As you approach a park, a menu will pop up that will allow you to play a recording. As you walk closer to the center icon, the recording volume will increase.</p>
-                                            <br />
-                                            <p>When you're in the center of the listening spot, you'll have the option to reorient your listening direction by turning with your phone. This will allow you to hear the recording in 360 degrees.</p>
-                                            <br />
-                                            <p>To hear a different recording from the same park, close the menu and another recording will load. To stop a recording, click the stop button or walk away from the park.</p>
-                                            <br />
-                                        </div>
-                                    </div>
+                            <Dialog.Panel className="relative w-full rounded-2xl bg-[#8ecdc0] p-8 shadow-2xl sm:my-8 sm:max-w-md">
+                                {/* decorative top rule */}
+                                <div className="mb-6 flex items-center gap-3">
+                                    <div className="h-px flex-1 bg-neutral-900/25" />
+                                    <span className="text-xs text-neutral-900/40 font-space-mono tracking-widest">✦</span>
+                                    <div className="h-px flex-1 bg-neutral-900/25" />
                                 </div>
-                                <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
 
+                                <Dialog.Title
+                                    as="h1"
+                                    className="font-cormorant text-5xl italic font-light tracking-tight text-neutral-900 mb-1"
+                                >
+                                    Resonant Landscapes
+                                </Dialog.Title>
+                                <p className="font-space-mono text-[10px] tracking-widest uppercase text-neutral-900/50 mb-7">
+                                    a walking soundscape
+                                </p>
+
+                                <div className="font-space-mono space-y-4 text-[12px] leading-relaxed text-neutral-900/75">
+                                    <p>Walk around DSU's campus to hear sounds recorded in each of South Dakota's 13 State Parks.</p>
+                                    <p>As you approach a park, a menu will appear. Walk closer to the center icon — the volume rises with proximity.</p>
+                                    <p>At the center of a listening spot, turn with your phone to hear the recording in 360 degrees.</p>
+                                    <p>Close the menu to load a different recording. Walk away or press stop to end.</p>
+                                </div>
+
+                                <div className="mt-8">
                                     <button
                                         type="button"
-                                        className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                                        className="w-full rounded-full bg-neutral-900 px-6 py-3 font-space-mono text-xs tracking-widest uppercase text-white transition-colors hover:bg-neutral-700"
                                         onClick={() => setIsOpen(false)}
                                         ref={cancelButtonRef}
                                     >
-                                        Continue
+                                        Begin
                                     </button>
                                 </div>
                             </Dialog.Panel>
@@ -76,4 +79,4 @@ function MyDialog({ isOpen, setIsOpen }: WelcomeModalProps) {
     )
 }
 
-export default MyDialog; 
+export default WelcomeModal;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,12 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        'cormorant': ['"Cormorant Garamond"', 'Georgia', 'serif'],
+        'space-mono': ['"Space Mono"', 'monospace'],
+      },
+    },
   },
   plugins: [],
 }

--- a/tests/audio-all-parks-mobile.spec.ts
+++ b/tests/audio-all-parks-mobile.spec.ts
@@ -35,7 +35,7 @@ type ParkRunResult = {
   failureReason: string | null;
 };
 
-const replayPath = "/#/debug";
+const replayPath = "/";
 const neutralPoint: Coordinate = [-97.1098, 44.0142];
 const scaleLat = 0.00066;
 const scaleLong = 0.00045;
@@ -75,10 +75,10 @@ function getExpectedSlug(parkName: string) {
 }
 
 async function dismissWelcomeIfPresent(page: Page) {
-  const continueButton = page.getByRole("button", { name: "Continue" });
-  if (await continueButton.count()) {
-    await continueButton.click();
-    await expect(page.getByRole("heading", { name: "Welcome to Resonant Landscapes" })).toHaveCount(0);
+  const beginButton = page.getByRole("button", { name: "Begin" });
+  if (await beginButton.count()) {
+    await beginButton.click();
+    await expect(page.getByRole("heading", { name: "Resonant Landscapes" })).toHaveCount(0);
   }
 }
 
@@ -134,10 +134,6 @@ test("mobile audio loads and plays for every debug map park", async ({ context, 
   await page.goto(replayPath);
   await page.waitForLoadState("domcontentloaded");
   await dismissWelcomeIfPresent(page);
-
-  const debugToggle = page.getByRole("button", { name: "Open" });
-  await expect(debugToggle).toBeVisible({ timeout: 10_000 });
-  await debugToggle.click();
 
   for (const park of debugParks) {
     const parkStartRequestIndex = observedAudioRequests.length;


### PR DESCRIPTION
Replace boilerplate Headless UI styling with mint green panels (#8ecdc0), Cormorant Garamond italic headings, Space Mono body copy, and near-black rounded-full CTAs. HelpModal tips converted to scannable dash list. ParkModal compact strip styled for rotation-active state. HOARenderer play/stop gets 44px tap targets and palette-matched switch colors. Test suite updated to match new button labels and normal route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned modal dialogs with updated color schemes, improved typography hierarchy, and refined content layouts.
  * Refined button styling and adjusted control labels for better consistency across the application.
  * Integrated new custom fonts (Cormorant Garamond and Space Mono) into the design system for enhanced visual presentation.

* **Tests**
  * Updated automated tests to align with recent interface navigation and interaction pattern changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->