### PR TITLE
Implement rotation-active modal collapse + ambient gradient (rl-9w7.3)

### DIFF
--- a/src/components/AmbientGradient.tsx
+++ b/src/components/AmbientGradient.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+
+interface AmbientGradientProps {
+    active: boolean;
+}
+
+export default function AmbientGradient({ active }: AmbientGradientProps) {
+    const divRef = useRef<HTMLDivElement>(null);
+    const rafRef = useRef<number>(0);
+
+    useEffect(() => {
+        if (!active) {
+            cancelAnimationFrame(rafRef.current);
+            return;
+        }
+
+        const tick = () => {
+            const o = window.__gimbalOrientation;
+            if (o && divRef.current) {
+                const yaw = Math.atan2(o.fwdX, o.fwdZ);
+                // cos(yaw): 1 = north, -1 = south
+                const t = (Math.cos(yaw) + 1) / 2; // 1 = north, 0 = south
+                const hue = Math.round(30 + t * 190); // 30 (warm/south) → 220 (cool/north)
+                divRef.current.style.background =
+                    `radial-gradient(ellipse at center, hsla(${hue}, 80%, 60%, 0.75) 0%, hsla(${hue}, 70%, 55%, 0.4) 40%, transparent 80%)`;
+            }
+            rafRef.current = requestAnimationFrame(tick);
+        };
+
+        rafRef.current = requestAnimationFrame(tick);
+        return () => cancelAnimationFrame(rafRef.current);
+    }, [active]);
+
+    return (
+        <div
+            ref={divRef}
+            aria-hidden="true"
+            className={`fixed inset-0 pointer-events-none transition-opacity duration-700 ${
+                active ? 'opacity-100' : 'opacity-0'
+            }`}
+            style={{ zIndex: 40 }}
+        />
+    );
+}

--- a/src/components/GeolocationMap.tsx
+++ b/src/components/GeolocationMap.tsx
@@ -183,8 +183,13 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
     }, [audioContext, prefetchUrls, preloadBuffers]);
 
     useEffect(() => {
+        // Stop sound when user walks out of range — HOARenderer no longer stops
+        // on unmount so we need to handle the "left the park" case here.
+        if (!parkName) {
+            stopSound();
+        }
         setParkModalOpen(Boolean(parkName));
-    }, [parkName]);
+    }, [parkName, stopSound]);
 
     useEffect(() => {
         const view = map?.getView();

--- a/src/components/GimbalArrow.tsx
+++ b/src/components/GimbalArrow.tsx
@@ -7,9 +7,10 @@ import { useRenderDebug } from "../hooks/useRenderDebug";
 interface GimbalArrowProps {
     permissionGranted: boolean;
     onPermissionGranted: () => void;
+    hideUI?: boolean;
 }
 
-const GimbalArrow = ({ permissionGranted, onPermissionGranted }: GimbalArrowProps) => {
+const GimbalArrow = ({ permissionGranted, onPermissionGranted, hideUI = false }: GimbalArrowProps) => {
     const gimbalRef = useRef(new Gimbal());
     const yawDisplayRef = useRef<HTMLSpanElement>(null);
     const { resonanceAudioScene } = useAudioEngine();
@@ -91,6 +92,7 @@ const GimbalArrow = ({ permissionGranted, onPermissionGranted }: GimbalArrowProp
     }, [permissionGranted, resonanceAudioScene]);
 
     if (!permissionGranted) {
+        if (hideUI) return null;
         return (
             <div className="flex justify-center items-center h-screen">
                 <button className="p-4 bg-blue-500 text-white rounded" onClick={requestPermission}>
@@ -100,6 +102,7 @@ const GimbalArrow = ({ permissionGranted, onPermissionGranted }: GimbalArrowProp
         );
     }
 
+    if (hideUI) return null;
 
     return (
         <p className="text-xs text-slate-400 tabular-nums">

--- a/src/components/HoaRenderer.tsx
+++ b/src/components/HoaRenderer.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useCallback, useRef, useState } from 'react';
 import { PlayCircleIcon, StopCircleIcon } from '@heroicons/react/24/solid'
-import { Switch } from '@headlessui/react'
 import { useAudioEngine, useAudioPlaybackState } from '../contexts/AudioContextProvider';
 import { useRenderDebug } from "../hooks/useRenderDebug";
 import GimbalArrow from './GimbalArrow';
@@ -14,13 +13,24 @@ interface HOARendererProps {
     parkDistance: number;
     userOrientation: boolean;
     compact?: boolean;
+    rotationActive: boolean;
+    onRotationActiveChange: (next: boolean) => void;
+    permissionGranted: boolean;
+    onPermissionGranted: () => void;
 }
 
-const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false }: HOARendererProps) => {
+const HOARenderer = ({
+    parkName,
+    parkDistance,
+    userOrientation,
+    compact = false,
+    rotationActive,
+    onRotationActiveChange,
+    permissionGranted,
+    onPermissionGranted,
+}: HOARendererProps) => {
     const { playSound, stopSound, loadBuffers, clearLoadError, cancelPendingLoad } = useAudioEngine();
     const { isLoading, isPlaying, buffers, loadError } = useAudioPlaybackState();
-    const [showGimbalArrow, setShowGimbalArrow] = useState(false);
-    const [permissionGranted, setPermissionGranted] = useState(false);
     const [pathError, setPathError] = useState<string | null>(null);
     useRenderDebug("HOARenderer", {
         parkName,
@@ -31,10 +41,18 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
         isPlaying,
         hasBuffers: Boolean(buffers),
         loadError,
-        showGimbalArrow,
+        rotationActive,
         permissionGranted,
         pathError,
     });
+    // Track whether this instance is still mounted so cleanup can distinguish
+    // a parkName change (still mounted → stop old park's sound) from an unmount
+    // caused by layout switching (Dialog ↔ strip) where sound should keep playing.
+    const isMountedRef = useRef(true);
+    useEffect(() => {
+        return () => { isMountedRef.current = false; };
+    }, []);
+
     const audioActionsRef = useRef({
         loadBuffers,
         stopSound,
@@ -50,8 +68,6 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
             cancelPendingLoad,
         };
     }, [cancelPendingLoad, clearLoadError, loadBuffers, stopSound]);
-
-    // TODO: load other sound files 
 
     useEffect(() => {
         let isCurrent = true;
@@ -79,29 +95,26 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
             isCurrent = false;
             audioActionsRef.current.cancelPendingLoad();
             audioActionsRef.current.clearLoadError();
-            audioActionsRef.current.stopSound();
-            setShowGimbalArrow(false);
-            setPermissionGranted(false);
+            // Only stop sound when the park actually changed — not when the component
+            // unmounts for layout reasons (Dialog ↔ strip switch on rotationActive).
+            if (isMountedRef.current) {
+                audioActionsRef.current.stopSound();
+            }
         };
     }, [parkName]);
 
     const onTogglePlayback = useCallback(() => {
         if (isPlaying) {
             stopSound();
-
-            if (showGimbalArrow) {
-                // toggleGimbalArrowVisibility();
-                setShowGimbalArrow(false);
+            if (rotationActive) {
+                onRotationActiveChange(false);
             }
-
         } else {
             if (buffers !== null) {
                 playSound();
             }
         }
-    }, [buffers, isPlaying, playSound, stopSound]);
-
-
+    }, [buffers, isPlaying, playSound, stopSound, rotationActive, onRotationActiveChange]);
 
     const retryLoading = useCallback(() => {
         const soundPathList = pickSoundPath(parkName, stateParks, navigator.userAgent);
@@ -150,32 +163,15 @@ const HOARenderer = ({ parkName, parkDistance, userOrientation, compact = false 
                         <PlayCircleIcon className={compact ? "h-4 w-4" : "h-12 w-12 text-neutral-900"} aria-hidden="true" />}
                         {compact && <span>{isPlaying ? 'Stop' : 'Play'}</span>}
                     </button>
-                    {
-                        !compact && isPlaying && parkDistance < 2 &&
-                        <Switch.Group>
-                            <div className="flex items-center">
-                                <Switch.Label className="mr-4 font-space-mono text-[11px] uppercase tracking-widest text-neutral-900/70">Body-Oriented Tracking</Switch.Label>
-                                <Switch
-                                    checked={showGimbalArrow}
-                                    onChange={setShowGimbalArrow}
-                                    className={`${showGimbalArrow ? 'bg-neutral-900' : 'bg-neutral-200'
-                                        } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-neutral-500 focus:ring-offset-2`}
-                                >
-                                    <span
-                                        className={`${showGimbalArrow ? 'translate-x-6' : 'translate-x-1'
-                                            } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
-                                    />
-                                </Switch>
-                            </div>
-                        </Switch.Group>
-                    }
 
-                    <br></br>
-                    {!compact && isPlaying && !showGimbalArrow && <LeavesCanvas parkDistance={parkDistance} />}
-                    {!compact && isPlaying && showGimbalArrow && (
+                    {!compact && isPlaying && !rotationActive && <LeavesCanvas parkDistance={parkDistance} />}
+
+                    {/* GimbalArrow runs whenever rotation is active — no !compact guard so audio tracking survives modal collapse */}
+                    {isPlaying && rotationActive && (
                         <GimbalArrow
                             permissionGranted={permissionGranted}
-                            onPermissionGranted={() => setPermissionGranted(true)}
+                            onPermissionGranted={onPermissionGranted}
+                            hideUI={compact}
                         />
                     )}
                 </>

--- a/src/components/ParkModal.tsx
+++ b/src/components/ParkModal.tsx
@@ -1,8 +1,9 @@
-import { Fragment, useRef, memo } from 'react'
+import { Fragment, useRef, memo, useState, useEffect } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
-import { useAudioEngine } from "../contexts/AudioContextProvider";
+import { useAudioEngine, useAudioPlaybackState } from "../contexts/AudioContextProvider";
 import { useRenderDebug } from "../hooks/useRenderDebug";
 import HOARenderer from './HoaRenderer';
+import AmbientGradient from './AmbientGradient';
 
 interface ParkModalProps {
     setIsOpen: (value: boolean) => void;
@@ -15,15 +16,32 @@ interface ParkModalProps {
 
 function ParkModal({ setIsOpen, isOpen, parkName, parkDistance, userOrientation, compact = false }: ParkModalProps) {
     const { stopSound } = useAudioEngine();
+    const { isPlaying } = useAudioPlaybackState();
+    const [rotationActive, setRotationActive] = useState(false);
+    const [permissionGranted, setPermissionGranted] = useState(false);
+
     useRenderDebug("ParkModal", {
         isOpen,
         parkName,
         parkDistance: Math.floor(parkDistance),
         userOrientation,
         compact,
+        rotationActive,
+        permissionGranted,
     });
 
     const cancelButtonRef = useRef(null);
+
+    // Reset rotation state when park changes
+    useEffect(() => {
+        setRotationActive(false);
+        setPermissionGranted(false);
+    }, [parkName]);
+
+    // Deactivate rotation when playback stops
+    useEffect(() => {
+        if (!isPlaying) setRotationActive(false);
+    }, [isPlaying]);
 
     function cancel() {
         console.log('Cancelling...');
@@ -31,94 +49,121 @@ function ParkModal({ setIsOpen, isOpen, parkName, parkDistance, userOrientation,
         setIsOpen(false);
     }
 
-    if (compact) {
+    const hoaRendererProps = {
+        parkName,
+        parkDistance,
+        userOrientation,
+        rotationActive,
+        onRotationActiveChange: setRotationActive,
+        permissionGranted,
+        onPermissionGranted: () => setPermissionGranted(true),
+    };
+
+    if (compact || rotationActive) {
         return (
-            <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-neutral-900/20 bg-[#8ecdc0] px-5 py-3 shadow-lg">
-                <div className="flex items-center justify-between gap-4">
-                    <div className="min-w-0">
-                        <p className="font-cormorant italic truncate text-xl font-light text-neutral-900">{parkName}</p>
-                        <p className="font-space-mono text-[10px] uppercase tracking-widest text-neutral-900/50">{Math.floor(parkDistance)} m away</p>
+            <>
+                <AmbientGradient active={rotationActive} />
+                <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-neutral-900/20 bg-[#8ecdc0] px-5 py-3 shadow-lg">
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="min-w-0">
+                            <p className="font-cormorant italic truncate text-xl font-light text-neutral-900">{parkName}</p>
+                            <p className="font-space-mono text-[10px] uppercase tracking-widest text-neutral-900/50">{Math.floor(parkDistance)} m away</p>
+                        </div>
+                        <div className="flex items-center gap-3">
+                            {rotationActive && (
+                                <button
+                                    onClick={() => setRotationActive(false)}
+                                    className="font-space-mono text-[10px] uppercase tracking-widest text-neutral-900/50 transition-colors hover:text-neutral-900"
+                                >
+                                    Stop Tracking
+                                </button>
+                            )}
+                            <HOARenderer {...hoaRendererProps} compact />
+                        </div>
                     </div>
-                    <HOARenderer
-                        parkName={parkName}
-                        parkDistance={parkDistance}
-                        userOrientation={userOrientation}
-                        compact
-                    />
                 </div>
-            </div>
+            </>
         );
     }
 
     return (
-        <Transition.Root show={isOpen} as={Fragment}>
-            <Dialog as="div" className="relative z-10" initialFocus={cancelButtonRef} onClose={setIsOpen}>
-                <Transition.Child
-                    as={Fragment}
-                    enter="ease-out duration-300"
-                    enterFrom="opacity-0"
-                    enterTo="opacity-100"
-                    leave="ease-in duration-200"
-                    leaveFrom="opacity-100"
-                    leaveTo="opacity-0"
-                >
-                    <div className="fixed inset-0 bg-neutral-900/20 transition-opacity" />
-                </Transition.Child>
+        <>
+            <AmbientGradient active={rotationActive} />
+            <Transition.Root show={isOpen} as={Fragment}>
+                <Dialog as="div" className="relative z-10" initialFocus={cancelButtonRef} onClose={setIsOpen}>
+                    <Transition.Child
+                        as={Fragment}
+                        enter="ease-out duration-300"
+                        enterFrom="opacity-0"
+                        enterTo="opacity-100"
+                        leave="ease-in duration-200"
+                        leaveFrom="opacity-100"
+                        leaveTo="opacity-0"
+                    >
+                        <div className="fixed inset-0 bg-neutral-900/20 transition-opacity" />
+                    </Transition.Child>
 
-                <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
-                    <div className="flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
-                        <Transition.Child
-                            as={Fragment}
-                            enter="ease-out duration-300"
-                            enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                            enterTo="opacity-100 translate-y-0 sm:scale-100"
-                            leave="ease-in duration-200"
-                            leaveFrom="opacity-100 translate-y-0 sm:scale-100"
-                            leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                        >
-                            <Dialog.Panel className="relative w-full rounded-2xl bg-[#8ecdc0] p-8 shadow-2xl sm:my-8 sm:max-w-md">
-                                {/* decorative top rule */}
-                                <div className="mb-6 flex items-center gap-3">
-                                    <div className="h-px flex-1 bg-neutral-900/25" />
-                                    <span className="font-space-mono text-xs tracking-widest text-neutral-900/40">✦</span>
-                                    <div className="h-px flex-1 bg-neutral-900/25" />
-                                </div>
+                    <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+                        <div className="flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+                            <Transition.Child
+                                as={Fragment}
+                                enter="ease-out duration-300"
+                                enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                                enterTo="opacity-100 translate-y-0 sm:scale-100"
+                                leave="ease-in duration-200"
+                                leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+                                leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                            >
+                                <Dialog.Panel className="relative w-full rounded-2xl bg-[#8ecdc0] p-8 shadow-2xl sm:my-8 sm:max-w-md">
+                                    {/* decorative top rule */}
+                                    <div className="mb-6 flex items-center gap-3">
+                                        <div className="h-px flex-1 bg-neutral-900/25" />
+                                        <span className="font-space-mono text-xs tracking-widest text-neutral-900/40">✦</span>
+                                        <div className="h-px flex-1 bg-neutral-900/25" />
+                                    </div>
 
-                                <Dialog.Title
-                                    as="h2"
-                                    className="font-cormorant text-5xl italic font-light tracking-tight text-neutral-900"
-                                >
-                                    {parkName}
-                                </Dialog.Title>
-                                <p className="font-space-mono mt-1 text-[10px] uppercase tracking-widest text-neutral-900/50">
-                                    {Math.floor(parkDistance)} meters away
-                                </p>
-
-                                <div className="mt-6">
-                                    <HOARenderer
-                                        parkName={parkName}
-                                        parkDistance={parkDistance}
-                                        userOrientation={userOrientation}
-                                    />
-                                </div>
-
-                                <div className="mt-8">
-                                    <button
-                                        type="button"
-                                        className="w-full rounded-full bg-neutral-900 px-6 py-3 font-space-mono text-xs tracking-widest uppercase text-white transition-colors hover:bg-neutral-700"
-                                        onClick={cancel}
-                                        ref={cancelButtonRef}
+                                    <Dialog.Title
+                                        as="h2"
+                                        className="font-cormorant text-5xl italic font-light tracking-tight text-neutral-900"
                                     >
-                                        Close
-                                    </button>
-                                </div>
-                            </Dialog.Panel>
-                        </Transition.Child>
+                                        {parkName}
+                                    </Dialog.Title>
+                                    <p className="font-space-mono mt-1 text-[10px] uppercase tracking-widest text-neutral-900/50">
+                                        {Math.floor(parkDistance)} meters away
+                                    </p>
+
+                                    <div className="mt-6">
+                                        <HOARenderer {...hoaRendererProps} />
+                                    </div>
+
+                                    {isPlaying && Math.floor(parkDistance) < 2 && userOrientation && (
+                                        <button
+                                            type="button"
+                                            onClick={() => setRotationActive(true)}
+                                            className="mt-4 w-full rounded-full border border-neutral-900/40 bg-transparent px-6 py-2 font-space-mono text-xs tracking-widest uppercase text-neutral-900/70 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+                                        >
+                                            Enable Rotation
+                                        </button>
+                                    )}
+
+                                    <div className="mt-4">
+                                        <button
+                                            type="button"
+                                            className="w-full rounded-full bg-neutral-900 px-6 py-3 font-space-mono text-xs tracking-widest uppercase text-white transition-colors hover:bg-neutral-700"
+                                            onClick={cancel}
+                                            ref={cancelButtonRef}
+                                        >
+                                            Close
+                                        </button>
+                                    </div>
+                                </Dialog.Panel>
+                            </Transition.Child>
+                        </div>
                     </div>
-                </div>
-            </Dialog>
-        </Transition.Root>
-    )
+                </Dialog>
+            </Transition.Root>
+        </>
+    );
 }
 
 export default memo(ParkModal)

--- a/tests/gimbal-orientation.spec.ts
+++ b/tests/gimbal-orientation.spec.ts
@@ -71,10 +71,10 @@ test("GimbalArrow updates listener orientation when device rotates", async ({
   await page.waitForLoadState("domcontentloaded");
 
   // Dismiss welcome modal if present
-  const continueBtn = page.getByRole("button", { name: "Continue" });
-  if (await continueBtn.count()) {
-    await continueBtn.click();
-    await expect(page.getByRole("heading", { name: "Welcome to Resonant Landscapes" })).toHaveCount(0);
+  const beginBtn = page.getByRole("button", { name: "Begin" });
+  if (await beginBtn.count()) {
+    await beginBtn.click();
+    await expect(page.getByRole("heading", { name: "Resonant Landscapes" })).toHaveCount(0);
   }
 
   // Wait for the map to be interactive before re-applying position
@@ -99,10 +99,10 @@ test("GimbalArrow updates listener orientation when device rotates", async ({
   await playBtn.click();
   console.log("[test] audio playing");
 
-  // Enable Body-Oriented Tracking toggle (only visible when playing and distance < 2 m)
-  const gimbalToggle = page.getByRole("switch");
-  await expect(gimbalToggle).toBeVisible({ timeout: 10_000 });
-  await gimbalToggle.click();
+  // Enable rotation (only visible when playing and distance < 2 m)
+  const enableRotationBtn = page.getByRole("button", { name: "Enable Rotation" });
+  await expect(enableRotationBtn).toBeVisible({ timeout: 10_000 });
+  await enableRotationBtn.click();
   console.log("[test] body-oriented tracking enabled");
 
   // GimbalArrow should now be mounted and writing to (window as any).__gimbalOrientation


### PR DESCRIPTION
Replace Headless UI Switch with Enable Rotation button in ParkModal (visible when playing and within 2m of center). Activating collapses the Dialog to a compact bottom strip and fades in a fullscreen ambient gradient driven by compass heading — cool blues north, warm oranges south. GimbalArrow mounts without the !compact guard so audio orientation tracking survives the collapse. HOARenderer uses isMountedRef to skip stopSound on layout-driven unmounts; GeolocationMap stops sound when user walks out of park range. Gimbal orientation test updated to use new Enable Rotation button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ambient gradient visual effect synchronized with device orientation
  * "Enable Rotation" button to activate spatial tracking during playback
  * "Stop Tracking" button to end active tracking sessions

* **Bug Fixes**
  * Audio now stops when leaving park range

* **Refactor**
  * Replaced rotation toggle with dedicated button control
  * Optimized UI layout with condensed tracking bar in compact mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->