### PR TITLE
Extend geolocation hook with prefetch coords/distance, modal always c…

### DIFF
--- a/src/components/GeolocationMap.tsx
+++ b/src/components/GeolocationMap.tsx
@@ -233,6 +233,7 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
                         parkName={parkName}
                         parkDistance={Math.floor(parkDistance)}
                         userOrientation={userOrientationEnabled}
+                        compact={true}
                     />
                 )}
             </ErrorBoundary>

--- a/src/hooks/useGeolocationTracking.ts
+++ b/src/hooks/useGeolocationTracking.ts
@@ -6,7 +6,7 @@ import type { ResonanceAudio } from "resonance-audio";
 
 import scaledPoints, { testPark } from "../utils/scaledParks";
 import { distanceInMeters } from "../utils/geo";
-import { selectNearestInRangePark } from "../utils/parkSelection";
+import { findClosestPark, selectNearestInRangePark } from "../utils/parkSelection";
 
 type Coordinate = [number, number];
 
@@ -44,6 +44,8 @@ export function useGeolocationTracking({
     const [parkName, setParkName] = useState("");
     const [parkDistance, setParkDistance] = useState(0);
     const [prefetchParkName, setPrefetchParkName] = useState("");
+    const [prefetchParkCoords, setPrefetchParkCoords] = useState<Coordinate | null>(null);
+    const [prefetchParkDistance, setPrefetchParkDistance] = useState(0);
     const [currentParkLocation, setCurrentParkLocation] = useState<Coordinate | null>(null);
     const [userOrientationEnabled, setUserOrientationEnabled] = useState(false);
     const [debugPermission, setDebugPermission] = useState("unknown");
@@ -103,18 +105,11 @@ export function useGeolocationTracking({
         setPosition(coordinates);
 
         const userLocation = toLonLat([coordinates[0], coordinates[1]]) as Coordinate;
-        let closestPark: ParkFeature | null = null;
-        let closestParkDistance = Number.POSITIVE_INFINITY;
-
-        for (const park of parkFeatures) {
-            const distance = distanceInMeters(userLocation, park.scaledCoords);
-            if (distance < closestParkDistance) {
-                closestPark = park;
-                closestParkDistance = distance;
-            }
-        }
-
-        setPrefetchParkName(closestPark && closestParkDistance < prefetchDistance ? closestPark.name : "");
+        const closest = findClosestPark(userLocation, parkFeatures);
+        const inPrefetchRange = Boolean(closest && closest.distance < prefetchDistance);
+        setPrefetchParkName(inPrefetchRange ? closest!.park.name : "");
+        setPrefetchParkCoords(inPrefetchRange ? closest!.park.scaledCoords : null);
+        setPrefetchParkDistance(inPrefetchRange ? closest!.distance : 0);
 
         const nearbyPark = selectNearestInRangePark(userLocation, parkFeatures, enterDistance);
 
@@ -190,6 +185,8 @@ export function useGeolocationTracking({
         parkFeatures,
         parkName,
         prefetchParkName,
+        prefetchParkCoords,
+        prefetchParkDistance,
         position,
         userOrientationEnabled,
     };

--- a/src/hooks/useGeolocationTracking.ts
+++ b/src/hooks/useGeolocationTracking.ts
@@ -6,9 +6,10 @@ import type { ResonanceAudio } from "resonance-audio";
 
 import scaledPoints, { testPark } from "../utils/scaledParks";
 import { distanceInMeters } from "../utils/geo";
-import { findClosestPark, selectNearestInRangePark } from "../utils/parkSelection";
+import { findClosestPark, PREFETCH_DISTANCE, selectNearestInRangePark } from "../utils/parkSelection";
 
 type Coordinate = [number, number];
+
 
 interface ParkFeature {
     name: string;
@@ -56,7 +57,7 @@ export function useGeolocationTracking({
 
     const enterDistance = 15;
     const exitDistance = 18;
-    const prefetchDistance = 40;
+    const prefetchDistance = PREFETCH_DISTANCE;
     const parkFeatures = useMemo<ParkFeature[]>(
         () => (debug ? [testPark, ...scaledPoints] : scaledPoints).map(toParkFeature),
         [debug]

--- a/src/utils/parkSelection.js
+++ b/src/utils/parkSelection.js
@@ -1,5 +1,7 @@
 import { distanceInMeters } from "./geo";
 
+export const PREFETCH_DISTANCE = 40; // meters — park enters approach-ring animation range
+
 /**
  * Returns the nearest park within maxDistance of userLocation,
  * or null if no parks qualify. Ignores array order.

--- a/src/utils/parkSelection.js
+++ b/src/utils/parkSelection.js
@@ -8,6 +8,29 @@ import { distanceInMeters } from "./geo";
  * @param {{ name: string; scaledCoords: [number, number] }[]} parks
  * @param {number} maxDistance - meters
  */
+/**
+ * Returns the closest park to userLocation and its distance, regardless of range.
+ * Returns null if parks is empty.
+ *
+ * @param {[number, number]} userLocation - [longitude, latitude]
+ * @param {{ name: string; scaledCoords: [number, number] }[]} parks
+ * @returns {{ park: object, distance: number } | null}
+ */
+export function findClosestPark(userLocation, parks) {
+  let closest = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  for (const park of parks) {
+    const distance = distanceInMeters(userLocation, park.scaledCoords);
+    if (distance < closestDistance) {
+      closest = park;
+      closestDistance = distance;
+    }
+  }
+
+  return closest ? { park: closest, distance: closestDistance } : null;
+}
+
 export function selectNearestInRangePark(userLocation, parks, maxDistance) {
   let nearest = null;
   let nearestDistance = Number.POSITIVE_INFINITY;

--- a/tests/prefetch-proximity.spec.ts
+++ b/tests/prefetch-proximity.spec.ts
@@ -6,14 +6,12 @@
  * returns the correct park coordinates and distance for the proximity animations.
  */
 import { test, expect } from "@playwright/test";
-import { findClosestPark } from "../src/utils/parkSelection";
+import { findClosestPark, PREFETCH_DISTANCE } from "../src/utils/parkSelection";
 
 type Park = {
     name: string;
     scaledCoords: [number, number];
 };
-
-const PREFETCH_DISTANCE = 40; // meters — matches useGeolocationTracking
 
 // Real scaled coordinates used in path-replay tests
 const SICA_HOLLOW: Park = {

--- a/tests/prefetch-proximity.spec.ts
+++ b/tests/prefetch-proximity.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for findClosestPark — the utility that drives prefetchParkCoords
+ * and prefetchParkDistance in useGeolocationTracking.
+ *
+ * These tests verify that when a user enters prefetch range (~40m), the hook
+ * returns the correct park coordinates and distance for the proximity animations.
+ */
+import { test, expect } from "@playwright/test";
+import { findClosestPark } from "../src/utils/parkSelection";
+
+type Park = {
+    name: string;
+    scaledCoords: [number, number];
+};
+
+const PREFETCH_DISTANCE = 40; // meters — matches useGeolocationTracking
+
+// Real scaled coordinates used in path-replay tests
+const SICA_HOLLOW: Park = {
+    name: "Sica Hollow State Park",
+    scaledCoords: [-97.11064914495, 44.01336371948],
+};
+
+const HARTFORD_BEACH: Park = {
+    name: "Hartford Beach State Park",
+    scaledCoords: [-97.11059202645, 44.01320393348],
+};
+
+// ~8m from Sica Hollow, ~18m from Hartford Beach (inside 15m enter range for Sica)
+const USER_NEAR_CENTER: [number, number] = [-97.110649, 44.01329];
+
+// ~20m from Hartford Beach, ~38m from Sica Hollow (inside prefetch, outside enter for both)
+const USER_APPROACHING: [number, number] = [-97.110649, 44.01302];
+
+// ~72m from Hartford Beach, ~90m from Sica Hollow (outside prefetch range)
+const USER_FAR: [number, number] = [-97.110649, 44.01255];
+
+test.describe("findClosestPark", () => {
+    test("returns closest park and its distance when user is near center", () => {
+        const result = findClosestPark(USER_NEAR_CENTER, [SICA_HOLLOW, HARTFORD_BEACH]);
+
+        expect(result).not.toBeNull();
+        expect(result!.park.name).toBe("Sica Hollow State Park");
+        expect(result!.distance).toBeLessThan(15);
+    });
+
+    test("returns closest park when user is in prefetch range but outside enter range", () => {
+        const result = findClosestPark(USER_APPROACHING, [SICA_HOLLOW, HARTFORD_BEACH]);
+
+        expect(result).not.toBeNull();
+        expect(result!.distance).toBeGreaterThan(15);
+        expect(result!.distance).toBeLessThan(PREFETCH_DISTANCE);
+    });
+
+    test("returns a result even when user is far away (caller checks range)", () => {
+        const result = findClosestPark(USER_FAR, [SICA_HOLLOW, HARTFORD_BEACH]);
+
+        // findClosestPark always returns the closest — caller decides if in range
+        expect(result).not.toBeNull();
+        expect(result!.distance).toBeGreaterThan(PREFETCH_DISTANCE);
+    });
+
+    test("caller can gate on prefetch distance to get prefetchParkCoords behavior", () => {
+        const near = findClosestPark(USER_APPROACHING, [SICA_HOLLOW, HARTFORD_BEACH]);
+        const far = findClosestPark(USER_FAR, [SICA_HOLLOW, HARTFORD_BEACH]);
+
+        const nearCoords = near && near.distance < PREFETCH_DISTANCE ? near.park.scaledCoords : null;
+        const farCoords = far && far.distance < PREFETCH_DISTANCE ? far.park.scaledCoords : null;
+
+        // Hartford Beach is closest at USER_APPROACHING (~20m vs ~38m for Sica Hollow)
+        expect(nearCoords).toEqual(HARTFORD_BEACH.scaledCoords);
+        expect(farCoords).toBeNull();
+    });
+
+    test("returns null for empty park list", () => {
+        const result = findClosestPark(USER_NEAR_CENTER, []);
+
+        expect(result).toBeNull();
+    });
+
+    test("returns the single park regardless of distance", () => {
+        const result = findClosestPark(USER_FAR, [SICA_HOLLOW]);
+
+        expect(result!.park.name).toBe("Sica Hollow State Park");
+    });
+});


### PR DESCRIPTION
…ompact

- Add findClosestPark() to parkSelection.js and use it in the hook to expose prefetchParkCoords and prefetchParkDistance for proximity animations
- Modal now always opens as compact bottom strip so map stays visible
- Add prefetch-proximity.spec.ts unit tests for findClosestPark

Closes rl-2zb, rl-72y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Park modal can now display in compact mode for improved UI flexibility.
  * Geolocation tracking now returns detailed closest park coordinates and distance information for enhanced proximity detection.

* **Tests**
  * Added comprehensive test suite for closest park selection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->