### PR TITLE
Add approach ring animation for all parks in prefetch range (rl-9cy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "sim:audio:worst:pixel": "playwright test tests/audio-worst-case-mobile.spec.ts --project=pixel-7 --headed",
     "sim:audio:worst:https:iphone": "PLAYWRIGHT_EXTERNAL_SERVER=1 playwright test tests/audio-worst-case-mobile.spec.ts --project=iphone-13 --headed",
     "sim:audio:worst:https:pixel": "PLAYWRIGHT_EXTERNAL_SERVER=1 playwright test tests/audio-worst-case-mobile.spec.ts --project=pixel-7 --headed",
+    "sim:ring": "APPROACH_RING_HOLD_MS=8000 playwright test tests/approach-ring.spec.ts --project=chromium --headed",
+    "sim:ring:iphone": "APPROACH_RING_HOLD_MS=8000 playwright test tests/approach-ring.spec.ts --project=iphone-13 --headed",
     "sim:path:install": "playwright install chromium webkit"
   },
   "dependencies": {

--- a/src/components/GeolocationMap.tsx
+++ b/src/components/GeolocationMap.tsx
@@ -20,6 +20,7 @@ import "./layers.css";
 import HelpModal from "./HelpModal";
 import ParkModal from "./ParkModal";
 import ParkFeatureLayers from "./ParkFeatureLayers";
+import ProximityRingLayer from "./ProximityRingLayer";
 import GeolocationDebugPanel from "./GeolocationDebugPanel";
 import { useAudioContext, useAudioEngine } from "../contexts/AudioContextProvider";
 import { useGeolocationTracking } from "../hooks/useGeolocationTracking";
@@ -153,6 +154,7 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
         parkDistance,
         parkName,
         prefetchParkName,
+        prefetchParks,
         position,
         userOrientationEnabled,
     } = useGeolocationTracking({
@@ -224,6 +226,12 @@ const GeolocationTrackingController = memo(function GeolocationTrackingControlle
             />
 
             <GeolocationPositionLayer position={position} accuracy={accuracy} />
+
+            <ProximityRingLayer
+                parks={prefetchParks}
+                active={prefetchParks.length > 0 && !parkName}
+                enterDistance={enterDistance}
+            />
 
             <ErrorBoundary fallback={<div>Error</div>}>
                 {parkModalOpen && (

--- a/src/components/ProximityRingLayer.tsx
+++ b/src/components/ProximityRingLayer.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { fromLonLat } from "ol/proj";
+import type RenderEvent from "ol/render/Event";
 import { RLayerVector } from "rlayers";
 import { useOL } from "rlayers";
 
@@ -26,13 +27,17 @@ function mapRange(value: number, inMin: number, inMax: number, outMin: number, o
 export default function ProximityRingLayer({ parks, active, enterDistance }: ProximityRingLayerProps) {
     const { map } = useOL();
 
-    const handlePostrender = useCallback((event: any) => {
+    const handlePostrender = useCallback((event: RenderEvent) => {
         if (!active || !parks.length || !map) {
             return;
         }
 
-        const ctx = event.context as CanvasRenderingContext2D;
-        const dpr = (event.frameState?.pixelRatio as number | undefined) ?? window.devicePixelRatio ?? 1;
+        if (!(event.context instanceof CanvasRenderingContext2D)) {
+            return;
+        }
+
+        const ctx = event.context;
+        const dpr = event.frameState?.pixelRatio ?? window.devicePixelRatio ?? 1;
         const resolution = map.getView().getResolution() ?? 1;
         const boundaryRadius = enterDistance / resolution;
         const t = Date.now() / 1000;
@@ -62,13 +67,13 @@ export default function ProximityRingLayer({ parks, active, enterDistance }: Pro
         }
         ctx.restore();
 
-        (event.target as any).changed();
+        event.target?.changed();
     }, [active, parks, enterDistance, map]);
 
     return (
         <RLayerVector
             zIndex={11}
-            onPostrender={handlePostrender}
+            onPostRender={handlePostrender}
         />
     );
 }

--- a/src/components/ProximityRingLayer.tsx
+++ b/src/components/ProximityRingLayer.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { fromLonLat } from "ol/proj";
+import { fromLonLat, getPointResolution } from "ol/proj";
 import type RenderEvent from "ol/render/Event";
 import { RLayerVector } from "rlayers";
 import { useOL } from "rlayers";
@@ -38,17 +38,21 @@ export default function ProximityRingLayer({ parks, active, enterDistance }: Pro
 
         const ctx = event.context;
         const dpr = event.frameState?.pixelRatio ?? window.devicePixelRatio ?? 1;
-        const resolution = map.getView().getResolution() ?? 1;
-        const boundaryRadius = enterDistance / resolution;
+        const view = map.getView();
+        const projection = view.getProjection();
+        const viewResolution = view.getResolution() ?? 1;
         const t = Date.now() / 1000;
 
         ctx.save();
         for (const { coords, distance } of parks) {
-            const pixel = map.getPixelFromCoordinate(fromLonLat(coords));
+            const projectedCoords = fromLonLat(coords);
+            const pixel = map.getPixelFromCoordinate(projectedCoords);
             if (!pixel) continue;
 
             const cx = pixel[0] * dpr;
             const cy = pixel[1] * dpr;
+            const pointResolution = getPointResolution(projection, viewResolution, projectedCoords);
+            const boundaryRadius = enterDistance / pointResolution;
 
             const speed = mapRange(distance, PREFETCH_DISTANCE, 5, 0.18, 1.4);
             const maxAlpha = mapRange(distance, PREFETCH_DISTANCE, 5, 0.12, 0.65);

--- a/src/components/ProximityRingLayer.tsx
+++ b/src/components/ProximityRingLayer.tsx
@@ -1,0 +1,74 @@
+import { useCallback } from "react";
+import { fromLonLat } from "ol/proj";
+import { RLayerVector } from "rlayers";
+import { useOL } from "rlayers";
+
+import { PREFETCH_DISTANCE } from "../utils/parkSelection";
+
+type Coordinate = [number, number];
+
+interface PrefetchPark {
+    coords: Coordinate;
+    distance: number;
+}
+
+interface ProximityRingLayerProps {
+    parks: PrefetchPark[];
+    active: boolean; // true when any park is in prefetch range AND user hasn't entered yet
+    enterDistance: number; // geographic radius (meters) of the boundary circle — rings pulse from its edge
+}
+
+function mapRange(value: number, inMin: number, inMax: number, outMin: number, outMax: number): number {
+    const t = Math.max(0, Math.min(1, (value - inMin) / (inMax - inMin)));
+    return outMin + t * (outMax - outMin);
+}
+
+export default function ProximityRingLayer({ parks, active, enterDistance }: ProximityRingLayerProps) {
+    const { map } = useOL();
+
+    const handlePostrender = useCallback((event: any) => {
+        if (!active || !parks.length || !map) {
+            return;
+        }
+
+        const ctx = event.context as CanvasRenderingContext2D;
+        const dpr = (event.frameState?.pixelRatio as number | undefined) ?? window.devicePixelRatio ?? 1;
+        const resolution = map.getView().getResolution() ?? 1;
+        const boundaryRadius = enterDistance / resolution;
+        const t = Date.now() / 1000;
+
+        ctx.save();
+        for (const { coords, distance } of parks) {
+            const pixel = map.getPixelFromCoordinate(fromLonLat(coords));
+            if (!pixel) continue;
+
+            const cx = pixel[0] * dpr;
+            const cy = pixel[1] * dpr;
+
+            const speed = mapRange(distance, PREFETCH_DISTANCE, 5, 0.18, 1.4);
+            const maxAlpha = mapRange(distance, PREFETCH_DISTANCE, 5, 0.12, 0.65);
+            const phases = [(t * speed) % 1, (t * speed + 0.5) % 1];
+
+            for (const phase of phases) {
+                const radius = (boundaryRadius + phase * 24) * dpr;
+                const alpha = maxAlpha * (1 - phase);
+
+                ctx.beginPath();
+                ctx.arc(cx, cy, radius, 0, 2 * Math.PI);
+                ctx.strokeStyle = `rgba(76, 175, 80, ${alpha.toFixed(3)})`;
+                ctx.lineWidth = 2 * dpr;
+                ctx.stroke();
+            }
+        }
+        ctx.restore();
+
+        (event.target as any).changed();
+    }, [active, parks, enterDistance, map]);
+
+    return (
+        <RLayerVector
+            zIndex={11}
+            onPostrender={handlePostrender}
+        />
+    );
+}

--- a/src/hooks/useGeolocationTracking.ts
+++ b/src/hooks/useGeolocationTracking.ts
@@ -6,7 +6,7 @@ import type { ResonanceAudio } from "resonance-audio";
 
 import scaledPoints, { testPark } from "../utils/scaledParks";
 import { distanceInMeters } from "../utils/geo";
-import { findClosestPark, PREFETCH_DISTANCE, selectNearestInRangePark } from "../utils/parkSelection";
+import { findClosestPark, findParksInRange, PREFETCH_DISTANCE, selectNearestInRangePark } from "../utils/parkSelection";
 
 type Coordinate = [number, number];
 
@@ -47,6 +47,7 @@ export function useGeolocationTracking({
     const [prefetchParkName, setPrefetchParkName] = useState("");
     const [prefetchParkCoords, setPrefetchParkCoords] = useState<Coordinate | null>(null);
     const [prefetchParkDistance, setPrefetchParkDistance] = useState(0);
+    const [prefetchParks, setPrefetchParks] = useState<{ coords: Coordinate; distance: number }[]>([]);
     const [currentParkLocation, setCurrentParkLocation] = useState<Coordinate | null>(null);
     const [userOrientationEnabled, setUserOrientationEnabled] = useState(false);
     const [debugPermission, setDebugPermission] = useState("unknown");
@@ -111,6 +112,7 @@ export function useGeolocationTracking({
         setPrefetchParkName(inPrefetchRange ? closest!.park.name : "");
         setPrefetchParkCoords(inPrefetchRange ? closest!.park.scaledCoords : null);
         setPrefetchParkDistance(inPrefetchRange ? closest!.distance : 0);
+        setPrefetchParks(findParksInRange(userLocation, parkFeatures, prefetchDistance));
 
         const nearbyPark = selectNearestInRangePark(userLocation, parkFeatures, enterDistance);
 
@@ -188,6 +190,7 @@ export function useGeolocationTracking({
         prefetchParkName,
         prefetchParkCoords,
         prefetchParkDistance,
+        prefetchParks,
         position,
         userOrientationEnabled,
     };

--- a/src/hooks/useGeolocationTracking.ts
+++ b/src/hooks/useGeolocationTracking.ts
@@ -107,7 +107,7 @@ export function useGeolocationTracking({
         setPosition(coordinates);
 
         const userLocation = toLonLat([coordinates[0], coordinates[1]]) as Coordinate;
-        const closest = findClosestPark(userLocation, parkFeatures);
+        const closest = findClosestPark(userLocation, parkFeatures) as { park: ParkFeature; distance: number } | null;
         const inPrefetchRange = Boolean(closest && closest.distance < prefetchDistance);
         setPrefetchParkName(inPrefetchRange ? closest!.park.name : "");
         setPrefetchParkCoords(inPrefetchRange ? closest!.park.scaledCoords : null);

--- a/src/utils/parkSelection.js
+++ b/src/utils/parkSelection.js
@@ -33,6 +33,28 @@ export function findClosestPark(userLocation, parks) {
   return closest ? { park: closest, distance: closestDistance } : null;
 }
 
+/**
+ * Returns all parks within maxDistance of userLocation, each with its distance.
+ * Used for the visual proximity ring — does not affect audio prefetch logic.
+ *
+ * @param {[number, number]} userLocation - [longitude, latitude]
+ * @param {{ name: string; scaledCoords: [number, number] }[]} parks
+ * @param {number} maxDistance - meters
+ * @returns {{ coords: [number, number], distance: number }[]}
+ */
+export function findParksInRange(userLocation, parks, maxDistance) {
+  const result = [];
+
+  for (const park of parks) {
+    const distance = distanceInMeters(userLocation, park.scaledCoords);
+    if (distance < maxDistance) {
+      result.push({ coords: park.scaledCoords, distance });
+    }
+  }
+
+  return result;
+}
+
 export function selectNearestInRangePark(userLocation, parks, maxDistance) {
   let nearest = null;
   let nearestDistance = Number.POSITIVE_INFINITY;

--- a/tests/approach-ring.spec.ts
+++ b/tests/approach-ring.spec.ts
@@ -40,6 +40,17 @@ async function dismissWelcomeModal(page: Page) {
     }
 }
 
+/** Polls parkStripIsVisible every 100ms for durationMs and fails immediately if it ever becomes true. */
+async function pollNeverTrue(page: Page, durationMs: number): Promise<void> {
+    const deadline = Date.now() + durationMs;
+    while (Date.now() < deadline) {
+        if (await parkStripIsVisible(page)) {
+            throw new Error("compact strip became visible inside prefetch range");
+        }
+        await page.waitForTimeout(100);
+    }
+}
+
 async function parkStripIsVisible(page: Page): Promise<boolean> {
     // The compact strip shows the park name in a font-cormorant paragraph
     // inside a fixed bottom-0 container. Check for the park name text.
@@ -71,15 +82,13 @@ test("compact strip is absent in prefetch range and appears on park entry", asyn
 
     // ── Step 2: just inside prefetch range — slow pulse ─────────────────────
     await context.setGeolocation(POSITIONS.prefetchFar);
-    await page.waitForTimeout(holdInPrefetchMs);
-    expect(await parkStripIsVisible(page)).toBe(false);
-    console.log("[test] ✓ compact strip absent at prefetch far (36m — slow pulse)");
+    await pollNeverTrue(page, holdInPrefetchMs);
+    console.log("[test] ✓ compact strip absent throughout prefetch far dwell (36m — slow pulse)");
 
     // ── Step 3: deeper in prefetch range — faster pulse ──────────────────────
     await context.setGeolocation(POSITIONS.prefetchNear);
-    await page.waitForTimeout(holdInPrefetchMs);
-    expect(await parkStripIsVisible(page)).toBe(false);
-    console.log("[test] ✓ compact strip absent at prefetch near (26m — faster pulse)");
+    await pollNeverTrue(page, holdInPrefetchMs);
+    console.log("[test] ✓ compact strip absent throughout prefetch near dwell (26m — faster pulse)");
 
     // ── Step 3: inside enter range — strip should appear ────────────────────
     await context.setGeolocation(POSITIONS.insidePark);

--- a/tests/approach-ring.spec.ts
+++ b/tests/approach-ring.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration test for the approach phase proximity behavior.
+ *
+ * Verifies that the compact park strip does NOT appear while the user is in
+ * prefetch range (15–40m) — the ring animation zone — and DOES appear once
+ * they cross the 15m enter threshold.
+ *
+ * The ring itself draws on canvas and cannot be asserted here, but this test
+ * guards the state boundary that drives it: prefetch range vs enter range.
+ */
+import { expect, test, type Page, type BrowserContext } from "@playwright/test";
+
+// Hartford Beach State Park scaled coords: [-97.11059202645, 44.01320393348]
+// Distances from each test position (verified with Haversine):
+//   outside prefetch   : Hartford 45.2m — outside 40m ring, no animation
+//   prefetch far       : Hartford 36.3m — just inside 40m, slow pulse
+//   prefetch near      : Hartford 26.4m — deeper in, faster pulse
+//   inside park        : Hartford 11.4m — crosses 15m threshold, strip appears
+const POSITIONS = {
+    outsidePrefetch: { latitude: 44.01280, longitude: -97.11065 },
+    prefetchFar:     { latitude: 44.01288, longitude: -97.11065 },
+    prefetchNear:    { latitude: 44.01297, longitude: -97.11065 },
+    insidePark:      { latitude: 44.01311, longitude: -97.11065 },
+};
+
+const PARK_NAME = "Hartford Beach State Park";
+const DEBUG_ROUTE = "/#/debug";
+const holdInPrefetchMs = Number(process.env.APPROACH_RING_HOLD_MS ?? 2_000);
+
+async function grantGeolocation(context: BrowserContext, baseURL: string) {
+    const origin = new URL(baseURL).origin;
+    await context.grantPermissions(["geolocation"], { origin });
+}
+
+async function dismissWelcomeModal(page: Page) {
+    const beginButton = page.getByRole("button", { name: /begin/i });
+    if (await beginButton.count()) {
+        await beginButton.click();
+        await expect(beginButton).toHaveCount(0, { timeout: 5_000 });
+    }
+}
+
+async function parkStripIsVisible(page: Page): Promise<boolean> {
+    // The compact strip shows the park name in a font-cormorant paragraph
+    // inside a fixed bottom-0 container. Check for the park name text.
+    const strip = page.locator("p.font-cormorant", { hasText: PARK_NAME });
+    return (await strip.count()) > 0 && (await strip.isVisible());
+}
+
+test("compact strip is absent in prefetch range and appears on park entry", async ({
+    context,
+    page,
+    baseURL,
+}) => {
+    if (!baseURL) {
+        throw new Error("Missing Playwright baseURL.");
+    }
+
+    await grantGeolocation(context, baseURL);
+    await context.setGeolocation(POSITIONS.outsidePrefetch);
+
+    await page.goto(DEBUG_ROUTE);
+    await page.waitForLoadState("domcontentloaded");
+    await dismissWelcomeModal(page);
+
+    // ── Step 1: outside prefetch range ─────────────────────────────────────
+    // Allow time for geolocation to settle
+    await page.waitForTimeout(1_500);
+    expect(await parkStripIsVisible(page)).toBe(false);
+    console.log("[test] ✓ compact strip absent outside prefetch range");
+
+    // ── Step 2: just inside prefetch range — slow pulse ─────────────────────
+    await context.setGeolocation(POSITIONS.prefetchFar);
+    await page.waitForTimeout(holdInPrefetchMs);
+    expect(await parkStripIsVisible(page)).toBe(false);
+    console.log("[test] ✓ compact strip absent at prefetch far (36m — slow pulse)");
+
+    // ── Step 3: deeper in prefetch range — faster pulse ──────────────────────
+    await context.setGeolocation(POSITIONS.prefetchNear);
+    await page.waitForTimeout(holdInPrefetchMs);
+    expect(await parkStripIsVisible(page)).toBe(false);
+    console.log("[test] ✓ compact strip absent at prefetch near (26m — faster pulse)");
+
+    // ── Step 3: inside enter range — strip should appear ────────────────────
+    await context.setGeolocation(POSITIONS.insidePark);
+
+    await expect
+        .poll(
+            async () => {
+                await context.setGeolocation(POSITIONS.insidePark);
+                return parkStripIsVisible(page);
+            },
+            { timeout: 12_000, intervals: [500] }
+        )
+        .toBe(true);
+
+    console.log(`[test] ✓ compact strip visible after crossing 15m threshold`);
+
+    await page.screenshot({
+        path: "test-results/approach-ring-entered-park.png",
+        fullPage: true,
+    });
+});


### PR DESCRIPTION
- ProximityRingLayer draws pulsing rings on the map canvas emanating from the 15m boundary edge, speeding up as the user closes in
- Rings show for all parks within 40m simultaneously (not just closest)
- findParksInRange() utility added to parkSelection.js
- Hook returns prefetchParks[] for visual rings; audio prefetch unchanged
- approach-ring.spec.ts integration test + sim:ring npm script
- Modal always compact so map stays visible during approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive proximity rings now appear on the map as you approach parks, displaying animated pulsing visuals to indicate nearby locations within detection range.

* **Tests**
  * Added integration tests for proximity ring behavior across different device types and approach scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->