### PR TITLE
Fix iPhone audio unlock flow

### DIFF
--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -14,13 +14,15 @@ function WelcomeModal({ isOpen, setIsOpen }: WelcomeModalProps) {
 
     const handleBegin = useCallback(async () => {
         try {
+            // iOS Safari requires this prompt to be initiated directly from a user gesture.
+            void requestDeviceOrientationPermission();
+
             const didUnlockAudio = await unlockAudio();
             if (!didUnlockAudio) {
                 return;
             }
 
             setIsOpen(false);
-            void requestDeviceOrientationPermission();
         } catch (error) {
             console.error("Error unlocking audio from welcome modal:", error);
         }

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,7 +1,6 @@
 import { useRef, Fragment, useCallback } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { useAudioContext } from "../contexts/AudioContextProvider";
-import { requestDeviceOrientationPermission } from "../utils/deviceOrientation";
 
 interface WelcomeModalProps {
     isOpen: boolean;
@@ -14,9 +13,6 @@ function WelcomeModal({ isOpen, setIsOpen }: WelcomeModalProps) {
 
     const handleBegin = useCallback(async () => {
         try {
-            // iOS Safari requires this prompt to be initiated directly from a user gesture.
-            void requestDeviceOrientationPermission();
-
             const didUnlockAudio = await unlockAudio();
             if (!didUnlockAudio) {
                 return;
@@ -80,7 +76,7 @@ function WelcomeModal({ isOpen, setIsOpen }: WelcomeModalProps) {
                                 </div>
 
                                 <p className="mt-6 font-space-mono text-[10px] uppercase tracking-widest text-neutral-900/55">
-                                    Begin will request audio and motion access.
+                                    Begin will request audio access. Rotation access is requested later when needed.
                                 </p>
 
                                 <div className="mt-8">
@@ -92,7 +88,7 @@ function WelcomeModal({ isOpen, setIsOpen }: WelcomeModalProps) {
                                         }}
                                         ref={cancelButtonRef}
                                     >
-                                        Begin With Audio + Motion
+                                        Begin With Audio
                                     </button>
                                 </div>
 

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -14,13 +14,13 @@ function WelcomeModal({ isOpen, setIsOpen }: WelcomeModalProps) {
 
     const handleBegin = useCallback(async () => {
         try {
-            const [didUnlockAudio, didUnlockMotion] = await Promise.all([
-                unlockAudio(),
-                requestDeviceOrientationPermission(),
-            ]);
-            if (didUnlockAudio && didUnlockMotion) {
-                setIsOpen(false);
+            const didUnlockAudio = await unlockAudio();
+            if (!didUnlockAudio) {
+                return;
             }
+
+            setIsOpen(false);
+            void requestDeviceOrientationPermission();
         } catch (error) {
             console.error("Error unlocking audio from welcome modal:", error);
         }

--- a/src/contexts/AudioContextProvider.tsx
+++ b/src/contexts/AudioContextProvider.tsx
@@ -76,6 +76,7 @@ const AudioContextProvider = ({ children }: { children: React.ReactNode }) => {
     const audioInitializedRef = useRef(false);
     const initAudioPromiseRef = useRef<Promise<void> | null>(null);
     const audioContextRef = useRef<AudioContext | null>(null);
+    const audioPrimedRef = useRef(false);
     const bufferSourceRef = useRef<AudioBufferSourceNode | null>(null);
     const lastAudioEventRef = useRef<string | null>(null);
     const activeLoadRequestIdRef = useRef(0);
@@ -288,6 +289,29 @@ const AudioContextProvider = ({ children }: { children: React.ReactNode }) => {
         syncAudioDebug("playback-started");
     }, [audioContext, buffers, resonanceAudioScene, syncAudioDebug]);
 
+    const primeAudioContext = useCallback((context: AudioContext) => {
+        if (audioPrimedRef.current) {
+            return;
+        }
+
+        const silentGain = context.createGain();
+        silentGain.gain.value = 0;
+        silentGain.connect(context.destination);
+
+        const buffer = context.createBuffer(1, 1, context.sampleRate);
+        const source = context.createBufferSource();
+        source.buffer = buffer;
+        source.connect(silentGain);
+        source.onended = () => {
+            source.disconnect();
+            silentGain.disconnect();
+        };
+        source.start(0);
+        source.stop(context.currentTime + 0.001);
+
+        audioPrimedRef.current = true;
+    }, []);
+
     const unlockAudio = useCallback(async (): Promise<boolean> => {
         try {
             if (initAudioPromiseRef.current) {
@@ -305,6 +329,8 @@ const AudioContextProvider = ({ children }: { children: React.ReactNode }) => {
                 await context.resume();
             }
 
+            primeAudioContext(context);
+
             setIsAudioUnlocked(true);
             syncAudioDebug("audio-unlocked");
             return true;
@@ -316,7 +342,7 @@ const AudioContextProvider = ({ children }: { children: React.ReactNode }) => {
             syncAudioDebug("unlock-error");
             return false;
         }
-    }, [syncAudioDebug]);
+    }, [primeAudioContext, syncAudioDebug]);
 
     const playSound = useCallback(() => {
         if (!audioContext || !resonanceAudioScene || isPlaying) {

--- a/src/hooks/useGeolocationTracking.ts
+++ b/src/hooks/useGeolocationTracking.ts
@@ -4,7 +4,7 @@ import { LineString } from "ol/geom";
 import { fromLonLat, toLonLat } from "ol/proj";
 import type { ResonanceAudio } from "resonance-audio";
 
-import scaledPoints, { testPark } from "../utils/scaledParks";
+import scaledPoints, { testParks } from "../utils/scaledParks";
 import { distanceInMeters } from "../utils/geo";
 import { findClosestPark, findParksInRange, PREFETCH_DISTANCE, selectNearestInRangePark } from "../utils/parkSelection";
 
@@ -60,7 +60,7 @@ export function useGeolocationTracking({
     const exitDistance = 18;
     const prefetchDistance = PREFETCH_DISTANCE;
     const parkFeatures = useMemo<ParkFeature[]>(
-        () => (debug ? [testPark, ...scaledPoints] : scaledPoints).map(toParkFeature),
+        () => (debug ? [...testParks, ...scaledPoints] : scaledPoints).map(toParkFeature),
         [debug]
     );
 

--- a/src/utils/audioPaths.js
+++ b/src/utils/audioPaths.js
@@ -4,6 +4,16 @@ const PARK_SLUG_OVERRIDES = {
   'Custer State Park': 'Custer-State',
   'Palisades State Park': 'Palisades-State',
 };
+const DEBUG_PARK_AUDIO_VARIANTS = {
+  'Custer Test': [[
+    `${CDN_BASE}sounds/Custer-Test-1-001_8ch.wav`,
+    `${CDN_BASE}sounds/Custer-Test-1-001_mono.wav`
+  ]],
+  'Current Location Test': [[
+    `${CDN_BASE}sounds/Custer-Test-1-001_8ch.wav`,
+    `${CDN_BASE}sounds/Custer-Test-1-001_mono.wav`
+  ]],
+};
 
 function hashString(value) {
   let hash = 0;
@@ -29,11 +39,8 @@ export function formatParkSlug(parkName) {
 }
 
 export function getParkAudioVariants(parkName, parksJSON, userAgent = '') {
-  if (parkName === 'Custer Test') {
-    return [[
-      `${CDN_BASE}sounds/Custer-Test-1-001_8ch.wav`,
-      `${CDN_BASE}sounds/Custer-Test-1-001_mono.wav`
-    ]];
+  if (DEBUG_PARK_AUDIO_VARIANTS[parkName]) {
+    return DEBUG_PARK_AUDIO_VARIANTS[parkName];
   }
 
   const foundPark = parksJSON.find((park) => park.name === parkName);

--- a/src/utils/scaledParks.js
+++ b/src/utils/scaledParks.js
@@ -19,6 +19,16 @@ const testPark = {
     scaledCoords: [-97.112994, 44.012224]
 };
 
+const currentLocationTestPark = {
+    name: "Current Location Test",
+    cords: [-96.741620, 43.552725],
+    recordingsCount: 1,
+    sectionsCount: 1,
+    scaledCoords: [-96.741620, 43.552725]
+};
+
+const testParks = [testPark, currentLocationTestPark];
+
 // Translate points to origin, apply scale, and translate back
 const scaledPoints = stateParks.map(park => {
     return {
@@ -27,6 +37,6 @@ const scaledPoints = stateParks.map(park => {
     };
 });
 
-export { testPark, scaledPoints };
+export { currentLocationTestPark, testPark, testParks, scaledPoints };
 
 export default scaledPoints;

--- a/tests/audio-all-parks-mobile.spec.ts
+++ b/tests/audio-all-parks-mobile.spec.ts
@@ -25,6 +25,19 @@ type AudioDebugState = {
   lastUnlockError: string | null;
 };
 
+type IosPermissionCall = {
+  hadGesture: boolean;
+  gestureType: string | null;
+  ts: number;
+};
+
+type IosPermissionHarnessState = {
+  motionPermissionCalls: number;
+  motionPermissionCallsDuringGesture: number;
+  motionPermissionCallsOutsideGesture: number;
+  calls: IosPermissionCall[];
+};
+
 type ParkRunResult = {
   parkName: string;
   loadTimeMs: number | null;
@@ -81,11 +94,85 @@ function getExpectedSlug(parkName: string) {
 }
 
 async function dismissWelcomeIfPresent(page: Page) {
-  const beginButton = page.getByRole("button", { name: "Begin" });
+  const beginButton = page.getByRole("button", { name: /begin/i });
   if (await beginButton.count()) {
     await beginButton.click();
     await expect(page.getByRole("heading", { name: "Resonant Landscapes" })).toHaveCount(0);
   }
+}
+
+async function installIPhoneSafariPermissionHarness(page: Page) {
+  await page.addInitScript(() => {
+    let activeGesture: { id: number; type: string } | null = null;
+    let gestureId = 0;
+    const state = {
+      motionPermissionCalls: 0,
+      motionPermissionCallsDuringGesture: 0,
+      motionPermissionCallsOutsideGesture: 0,
+      calls: [],
+    };
+
+    const markGesture = (type: string) => {
+      gestureId += 1;
+      const nextGesture = { id: gestureId, type };
+      activeGesture = nextGesture;
+
+      queueMicrotask(() => {
+        if (activeGesture?.id === nextGesture.id) {
+          activeGesture = null;
+        }
+      });
+
+      setTimeout(() => {
+        if (activeGesture?.id === nextGesture.id) {
+          activeGesture = null;
+        }
+      }, 0);
+    };
+
+    window.addEventListener("click", () => markGesture("click"), true);
+    window.addEventListener("touchend", () => markGesture("touchend"), true);
+    window.addEventListener("pointerup", () => markGesture("pointerup"), true);
+
+    const ctor = window.DeviceOrientationEvent ?? function DeviceOrientationEvent() {};
+    if (!window.DeviceOrientationEvent) {
+      Object.defineProperty(window, "DeviceOrientationEvent", {
+        configurable: true,
+        writable: true,
+        value: ctor,
+      });
+    }
+
+    Object.defineProperty(window, "__iosPermissionHarness", {
+      configurable: true,
+      value: state,
+    });
+
+    Object.defineProperty(ctor, "requestPermission", {
+      configurable: true,
+      value: async () => {
+        const call = {
+          hadGesture: Boolean(activeGesture),
+          gestureType: activeGesture?.type ?? null,
+          ts: Date.now(),
+        };
+
+        state.motionPermissionCalls += 1;
+        if (call.hadGesture) {
+          state.motionPermissionCallsDuringGesture += 1;
+        } else {
+          state.motionPermissionCallsOutsideGesture += 1;
+        }
+        state.calls.push(call);
+
+        if (!call.hadGesture) {
+          throw new Error("NotAllowedError: requestPermission() must be called during a user gesture");
+        }
+
+        return "granted";
+      },
+    });
+  });
 }
 
 async function moveToPoint(
@@ -108,6 +195,9 @@ async function getAudioDebug(page: Page) {
   return page.evaluate(() => window.__audioDebug ?? null) as Promise<AudioDebugState | null>;
 }
 
+async function getIosPermissionHarnessState(page: Page) {
+  return page.evaluate(() => window.__iosPermissionHarness ?? null) as Promise<IosPermissionHarnessState | null>;
+}
 
 test("mobile audio loads and plays for every debug map park", async ({ context, page, baseURL }, testInfo) => {
   test.skip(
@@ -125,6 +215,11 @@ test("mobile audio loads and plays for every debug map park", async ({ context, 
   const runResults: ParkRunResult[] = [];
   const failures: string[] = [];
   const observedAudioRequests: { url: string; ts: number }[] = [];
+  const useIPhonePermissionHarness = testInfo.project.name === "iphone-13";
+
+  if (useIPhonePermissionHarness) {
+    await installIPhoneSafariPermissionHarness(page);
+  }
 
   await context.route("https://resonant-landscapes.b-cdn.net/**", async (route) => {
     observedAudioRequests.push({
@@ -140,6 +235,14 @@ test("mobile audio loads and plays for every debug map park", async ({ context, 
   await page.goto(replayPath);
   await page.waitForLoadState("domcontentloaded");
   await dismissWelcomeIfPresent(page);
+
+  if (useIPhonePermissionHarness) {
+    await expect
+      .poll(async () => (await getIosPermissionHarnessState(page))?.motionPermissionCalls ?? 0, {
+        timeout: 5_000,
+      })
+      .toBe(0);
+  }
 
   for (const park of debugParks) {
     const parkStartRequestIndex = observedAudioRequests.length;
@@ -252,6 +355,9 @@ test("mobile audio loads and plays for every debug map park", async ({ context, 
     totalParks: debugParks.length,
     passed: runResults.filter((result) => result.status === "passed").length,
     failed: runResults.filter((result) => result.status === "failed").length,
+    iosPermissionHarness: useIPhonePermissionHarness
+      ? await getIosPermissionHarnessState(page)
+      : null,
     results: runResults,
   };
 

--- a/tests/audio-paths.test.mjs
+++ b/tests/audio-paths.test.mjs
@@ -58,6 +58,15 @@ test('Custer State Park uses the CDN slug override for both browser families', (
   assert.match(chromeVariants[12][1], /\/sounds\/Custer-State-7-001_mono\.m4a$/);
 });
 
+test('debug-only parks reuse the Custer Test audio pair', () => {
+  const custerTestVariants = getParkAudioVariants('Custer Test', stateParks, 'Chrome');
+  const currentLocationVariants = getParkAudioVariants('Current Location Test', stateParks, 'Chrome');
+
+  assert.deepEqual(currentLocationVariants, custerTestVariants);
+  assert.match(currentLocationVariants?.[0]?.[0] ?? '', /\/sounds\/Custer-Test-1-001_8ch\.wav$/);
+  assert.match(currentLocationVariants?.[0]?.[1] ?? '', /\/sounds\/Custer-Test-1-001_mono\.wav$/);
+});
+
 test('Palisades State Park uses the CDN slug override for both browser families', () => {
   const safariVariants = getParkAudioVariants('Palisades State Park', stateParks, 'Safari');
   const chromeVariants = getParkAudioVariants('Palisades State Park', stateParks, 'Chrome');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio unlock now runs first; if it fails, motion/orientation permission is not prompted.
  * Added one-time audio priming during the first unlock to improve audio reliability.

* **Changes**
  * Updated Begin button copy to remove “motion” and note rotation access will be requested later.
  * Welcome modal now closes immediately after successful audio unlock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->