### PR TITLE
Add master soft-limiter at scene output (rl-52o)

### DIFF
--- a/src/contexts/AudioContextProvider.tsx
+++ b/src/contexts/AudioContextProvider.tsx
@@ -433,7 +433,18 @@ const AudioContextProvider = ({ children }: { children: React.ReactNode }) => {
                 resonanceSceneRef.current = scene;
                 scene.setAmbisonicOrder(2);
                 setResonanceAudioScene(scene);
-                scene.output.connect(context.destination);
+                // Safety limiter: catches peaks only so a later gain bump or an
+                // unusually hot park recording can't clip mobile speakers. Field
+                // recordings must keep their dynamic range, so this must stay
+                // effectively inaudible on the natural signal.
+                const limiter = context.createDynamicsCompressor();
+                limiter.threshold.value = -1;
+                limiter.knee.value = 0;
+                limiter.ratio.value = 20;
+                limiter.attack.value = 0.005;
+                limiter.release.value = 0.15;
+                scene.output.connect(limiter);
+                limiter.connect(context.destination);
                 lastAudioEventRef.current = "audio-initialized";
             } catch (error) {
                 console.error('Error initializing audio:', error);


### PR DESCRIPTION
## Summary
- Insert a `DynamicsCompressorNode` between `scene.output` and `context.destination` in [AudioContextProvider.tsx](src/contexts/AudioContextProvider.tsx)
- Tuned as a brick-wall safety limiter: threshold -1 dBFS, ratio 20:1, 5 ms attack, 150 ms release, 0 dB knee
- Intended to stay inaudible on the natural field-recording signal; only catches peaks so future gain changes can't clip mobile speakers

## Why
Prep work for a small master-gain bump (next PR) — without this, raising gain on already-hot park recordings could clip on mobile speakers. Closes rl-52o from the rl-8bi loudness epic.

## Test plan
- [x] Verify playback sounds unchanged on Chrome desktop for a park whose peaks don't exceed -1 dBFS
- [ ] iPhone Safari sanity check: audio still plays, no audible artifacts on quieter passages
- [ ] After rl-6oz+3dB lands, confirm the limiter engages on the loudest peaks and prevents clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio output now prevents clipping and distortion from high-level signals or subsequent gain adjustments, resulting in cleaner audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->